### PR TITLE
feat: Auto-preview HTML response body in Response Viewer

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,7 @@ Common rules:
 - Put AI names (Claude, eFrank, etc.) in git commits, PR descriptions, or code comments
 
 ## Available Commands
+- `/ef-feature [github-issue-url]` — End-to-end feature workflow: fetch GitHub issue → understand context → plan → implement (with design quality) → evaluate E2E test needs
 - `/ef-dev [action]` — Start dev environment, or explore and record setup steps. Actions: `start` (default), `setup`, `explore`, `stop`
 - `/ef-plan [module-name]` — Break a module into features, set priorities and dependencies
 - `/ef-implement [feature-name]` — Full TDD workflow: acceptance spec → tests → implementation

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ Desktop.ini
 dev-start.*
 dev-stop.*
 
+# Active task state (per-developer)
+memory-bank/activeTask.md
+
 # Supabase local
 supabase/.temp
 supabase/.branches

--- a/acceptance/html-preview.md
+++ b/acceptance/html-preview.md
@@ -1,0 +1,72 @@
+# HTML Response Auto-Preview - Acceptance Criteria
+
+## Description (client-readable)
+When a response has HTML content, the Response Viewer automatically shows a rendered preview using a sandboxed iframe. Users can toggle between Preview and Raw views. Existing JSON and text rendering is unaffected.
+
+## Interface Contract
+This is the shared agreement between the Test Writer and the Implementer.
+
+### Detection Logic
+- Check `displayResponse.headers` array for an entry where `key` (case-insensitive) equals `content-type` and `value` contains `text/html`
+- Helper function: `isHtmlResponse(headers)` — returns boolean
+- **Priority rule**: JSON detection (`isJsonBody`) takes precedence over HTML detection. If the body parses as valid JSON, render as JSON tree even if Content-Type says `text/html`.
+- HTML detection only applies in non-example mode (when `isExample` is false)
+
+### UI Components
+
+#### Preview/Raw Toggle (within Body tab)
+- Only visible when response is detected as HTML (and not example mode)
+- Two buttons: "Preview" and "Raw"
+- Default selection: "Preview"
+- Location: inside the response-content area, above the body content
+- `data-testid="html-view-toggle"` on the toggle container
+- `data-testid="html-preview-btn"` on the Preview button
+- `data-testid="html-raw-btn"` on the Raw button
+- Active button gets class `active`
+
+#### HTML Preview (iframe)
+- Rendered via `<iframe>` with `srcDoc` attribute set to the response body string
+- `sandbox=""` attribute (most restrictive — no scripts, no forms, no same-origin)
+- `data-testid="html-preview-frame"` on the iframe
+- Iframe fills the response content area (width: 100%, flex: 1)
+- White background (regardless of app theme) for accurate HTML rendering
+- No border on iframe
+
+#### Raw View
+- Same as current non-JSON rendering: `<pre className="response-body">`
+- `data-testid="html-raw-body"` on the pre element
+- Shows the raw HTML source string
+
+### CSS Classes
+- `.html-view-toggle` — container for Preview/Raw buttons
+- `.html-view-toggle button` — individual toggle button
+- `.html-view-toggle button.active` — active state
+- `.html-preview-frame` — iframe styling
+- Style toggle buttons to match existing `.response-tabs` button pattern
+
+### Business Rules
+1. HTML detection is based solely on Content-Type header containing `text/html`
+2. JSON takes priority: if body parses as JSON, show JSON tree view regardless of Content-Type
+3. Default to Preview mode when HTML is first detected
+4. Toggle state resets when a new response is received (defaults back to Preview)
+5. Example mode always uses JsonEditor — HTML preview never applies to examples
+6. The iframe sandbox attribute must be the empty string `""` for maximum security
+7. Non-HTML, non-JSON responses continue rendering as raw `<pre>` text
+
+## Frontend Acceptance Tests
+| ID | User Action | Expected Result |
+|----|------------|----------------|
+| FE-001 | Send request that returns Content-Type: text/html with HTML body | Response body area shows rendered HTML in an iframe; Preview button is active |
+| FE-002 | Click "Raw" button on an HTML response | Iframe is hidden, raw HTML source shown in pre element |
+| FE-003 | Click "Preview" button after switching to Raw | Iframe re-appears with rendered HTML, Raw view hidden |
+| FE-004 | Send request that returns Content-Type: application/json | JSON tree view shown, no Preview/Raw toggle visible |
+| FE-005 | Send request that returns Content-Type: text/html but body is valid JSON | JSON tree view shown (JSON priority), no Preview/Raw toggle |
+| FE-006 | View an example with HTML body | JsonEditor shown (example mode), no iframe preview |
+
+## Test Status
+- [ ] FE-001: Pending
+- [ ] FE-002: Pending
+- [ ] FE-003: Pending
+- [ ] FE-004: Pending
+- [ ] FE-005: Pending
+- [ ] FE-006: Pending

--- a/e2e/html-preview.spec.ts
+++ b/e2e/html-preview.spec.ts
@@ -1,0 +1,260 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTestCollections } from './helpers/cleanup';
+
+// Generate unique names for each test run
+const timestamp = Date.now();
+const uniqueName = (base: string) => `${base} ${timestamp}`;
+
+test.afterAll(async () => { await cleanupTestCollections(timestamp); });
+
+// Helper to create a collection and request for testing
+async function createTestRequest(page, collectionName: string) {
+  const addCollectionBtn = page.locator('.sidebar-toolbar .btn-icon').last();
+  await expect(addCollectionBtn).toBeEnabled({ timeout: 10000 });
+  await addCollectionBtn.click();
+
+  const promptModal = page.locator('.prompt-modal');
+  await expect(promptModal).toBeVisible({ timeout: 5000 });
+  await promptModal.locator('.prompt-input').fill(collectionName);
+  await promptModal.locator('.prompt-btn-confirm').click();
+  await expect(promptModal).not.toBeVisible();
+
+  const collectionHeader = page.locator('.collection-header').filter({ hasText: collectionName });
+  await expect(collectionHeader).toBeVisible({ timeout: 5000 });
+  await collectionHeader.hover();
+  await collectionHeader.locator('.btn-menu').click();
+
+  const collectionMenu = page.locator('.collection-menu');
+  await expect(collectionMenu).toBeVisible();
+  await collectionMenu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+
+  const requestItem = page.locator('.request-item').filter({ hasText: 'New Request' }).first();
+  await expect(requestItem).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+}
+
+// Helper to send a request and wait for response
+async function sendRequestAndWaitForResponse(page) {
+  const sendButton = page.locator('.btn-send');
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+
+  const responseViewer = page.locator('.response-viewer').first();
+  await expect(responseViewer).toBeVisible({ timeout: 15000 });
+  await expect(responseViewer.locator('.response-meta')).toBeVisible({ timeout: 15000 });
+}
+
+// Helper to save current request/response as an example
+async function saveAsExample(page, exampleName: string) {
+  await page.locator('.btn-save-dropdown').click();
+  const saveDropdownMenu = page.locator('.save-dropdown-menu');
+  await expect(saveDropdownMenu).toBeVisible();
+  await saveDropdownMenu.locator('.save-dropdown-item').filter({ hasText: 'Save as Example' }).click();
+
+  const exampleModal = page.locator('.save-example-modal');
+  await expect(exampleModal).toBeVisible({ timeout: 5000 });
+  await exampleModal.locator('.example-name-input').fill(exampleName);
+  await exampleModal.locator('.btn-confirm').click();
+  await expect(exampleModal).not.toBeVisible({ timeout: 5000 });
+}
+
+test.describe('HTML Preview', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+    await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('FE-001: HTML response shows rendered preview in iframe with Preview button active', async ({ page }) => {
+    const collectionName = uniqueName('HTML Preview Collection');
+    await createTestRequest(page, collectionName);
+
+    // Use a URL that returns text/html content (e.g., httpbin returns HTML for /html)
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/html');
+
+    await sendRequestAndWaitForResponse(page);
+
+    // The toggle container should be visible for HTML responses
+    const toggleContainer = page.locator('[data-testid="html-view-toggle"]');
+    await expect(toggleContainer).toBeVisible({ timeout: 10000 });
+
+    // Preview button should be visible and active (default mode)
+    const previewBtn = page.locator('[data-testid="html-preview-btn"]');
+    await expect(previewBtn).toBeVisible();
+    await expect(previewBtn).toHaveClass(/active/);
+
+    // The iframe should be visible with the HTML content
+    const iframe = page.locator('[data-testid="html-preview-frame"]');
+    await expect(iframe).toBeVisible();
+
+    // The iframe should have sandbox="" for security
+    await expect(iframe).toHaveAttribute('sandbox', '');
+
+    // Raw body should NOT be visible in preview mode
+    const rawBody = page.locator('[data-testid="html-raw-body"]');
+    await expect(rawBody).not.toBeVisible();
+  });
+
+  test('FE-002: clicking Raw button hides iframe and shows raw HTML source', async ({ page }) => {
+    const collectionName = uniqueName('HTML Raw Collection');
+    await createTestRequest(page, collectionName);
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/html');
+
+    await sendRequestAndWaitForResponse(page);
+
+    // Wait for toggle to appear
+    const toggleContainer = page.locator('[data-testid="html-view-toggle"]');
+    await expect(toggleContainer).toBeVisible({ timeout: 10000 });
+
+    // Click the Raw button
+    const rawBtn = page.locator('[data-testid="html-raw-btn"]');
+    await expect(rawBtn).toBeVisible();
+    await rawBtn.click();
+
+    // Raw button should now be active
+    await expect(rawBtn).toHaveClass(/active/);
+
+    // Preview button should no longer be active
+    const previewBtn = page.locator('[data-testid="html-preview-btn"]');
+    await expect(previewBtn).not.toHaveClass(/active/);
+
+    // Iframe should be hidden
+    const iframe = page.locator('[data-testid="html-preview-frame"]');
+    await expect(iframe).not.toBeVisible();
+
+    // Raw HTML source should be visible in a pre element
+    const rawBody = page.locator('[data-testid="html-raw-body"]');
+    await expect(rawBody).toBeVisible();
+
+    // Raw body should contain HTML markup
+    await expect(rawBody).toContainText('<');
+  });
+
+  test('FE-003: clicking Preview after Raw re-shows iframe and hides raw', async ({ page }) => {
+    const collectionName = uniqueName('HTML Toggle Collection');
+    await createTestRequest(page, collectionName);
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/html');
+
+    await sendRequestAndWaitForResponse(page);
+
+    const toggleContainer = page.locator('[data-testid="html-view-toggle"]');
+    await expect(toggleContainer).toBeVisible({ timeout: 10000 });
+
+    // Switch to Raw first
+    const rawBtn = page.locator('[data-testid="html-raw-btn"]');
+    await rawBtn.click();
+    await expect(rawBtn).toHaveClass(/active/);
+
+    // Now switch back to Preview
+    const previewBtn = page.locator('[data-testid="html-preview-btn"]');
+    await previewBtn.click();
+
+    // Preview button should be active again
+    await expect(previewBtn).toHaveClass(/active/);
+
+    // Raw button should no longer be active
+    await expect(rawBtn).not.toHaveClass(/active/);
+
+    // Iframe should re-appear
+    const iframe = page.locator('[data-testid="html-preview-frame"]');
+    await expect(iframe).toBeVisible();
+
+    // Raw body should be hidden
+    const rawBody = page.locator('[data-testid="html-raw-body"]');
+    await expect(rawBody).not.toBeVisible();
+  });
+
+  test('FE-004: JSON response shows JSON tree view with no HTML toggle', async ({ page }) => {
+    const collectionName = uniqueName('JSON No Toggle Collection');
+    await createTestRequest(page, collectionName);
+
+    // Use a URL that returns application/json
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/get');
+
+    await sendRequestAndWaitForResponse(page);
+
+    // The HTML toggle should NOT be visible for JSON responses
+    const toggleContainer = page.locator('[data-testid="html-view-toggle"]');
+    await expect(toggleContainer).not.toBeVisible({ timeout: 5000 });
+
+    // No iframe should be present
+    const iframe = page.locator('[data-testid="html-preview-frame"]');
+    await expect(iframe).not.toBeVisible();
+
+    // The response viewer should show JSON tree view (existing component)
+    const responseViewer = page.locator('.response-viewer').first();
+    await expect(responseViewer).toBeVisible();
+  });
+
+  test('FE-005: HTML Content-Type with valid JSON body shows JSON tree, no HTML toggle', async ({ page }) => {
+    const collectionName = uniqueName('HTML JSON Priority Collection');
+    await createTestRequest(page, collectionName);
+
+    // Change method to POST to use httpbin /response-headers which lets us set custom headers
+    // Use httpbin /response-headers to get a response with text/html content-type but JSON body
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/response-headers?Content-Type=text/html&freeform={"key":"value"}');
+
+    await sendRequestAndWaitForResponse(page);
+
+    // JSON should take priority: the HTML toggle should NOT be visible
+    const toggleContainer = page.locator('[data-testid="html-view-toggle"]');
+    await expect(toggleContainer).not.toBeVisible({ timeout: 5000 });
+
+    // No iframe should be present
+    const iframe = page.locator('[data-testid="html-preview-frame"]');
+    await expect(iframe).not.toBeVisible();
+  });
+
+  test('FE-006: example mode with HTML body shows JsonEditor, no iframe preview', async ({ page }) => {
+    const collectionName = uniqueName('HTML Example Collection');
+    const exampleName = uniqueName('HTML Example');
+    await createTestRequest(page, collectionName);
+
+    // Set URL to return HTML
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/html');
+
+    // Save the request first (required for saving examples)
+    const saveBtn = page.locator('.btn-save');
+    await saveBtn.click();
+    await expect(saveBtn).not.toContainText('*', { timeout: 5000 });
+
+    // Send request to get a response
+    await sendRequestAndWaitForResponse(page);
+
+    // Verify HTML preview is shown in request mode (sanity check)
+    const toggleContainer = page.locator('[data-testid="html-view-toggle"]');
+    await expect(toggleContainer).toBeVisible({ timeout: 10000 });
+
+    // Save as example
+    await saveAsExample(page, exampleName);
+
+    // Example tab should open automatically
+    const exampleTab = page.locator('.open-tab').filter({ hasText: exampleName });
+    await expect(exampleTab).toBeVisible({ timeout: 10000 });
+
+    // Click the example tab to activate it
+    await exampleTab.click();
+
+    // In example mode, there should be no HTML toggle or iframe
+    const exampleToggle = page.locator('[data-testid="html-view-toggle"]');
+    await expect(exampleToggle).not.toBeVisible({ timeout: 5000 });
+
+    const exampleIframe = page.locator('[data-testid="html-preview-frame"]');
+    await expect(exampleIframe).not.toBeVisible();
+
+    // JsonEditor should be used instead (CodeMirror editor for response body)
+    const jsonEditor = page.locator('.json-editor-wrapper, .cm-editor');
+    await expect(jsonEditor.first()).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/src/App.css
+++ b/src/App.css
@@ -1453,18 +1453,23 @@ body {
 }
 
 .auth-type-selector {
+  margin-bottom: 16px;
+}
+
+/* Shared option selector (pill-style radio/button group) */
+.option-selector {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: 6px;
   flex-shrink: 0;
 }
 
-.auth-type-selector label {
+.option-selector label,
+.option-selector button {
   position: relative;
   display: flex;
   align-items: center;
-  padding: 6px 14px;
+  padding: 4px 14px;
   background: transparent;
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
@@ -1476,25 +1481,28 @@ body {
   user-select: none;
 }
 
-.auth-type-selector label:hover {
+.option-selector label:hover,
+.option-selector button:hover {
   background: var(--bg-hover);
   border-color: var(--border-secondary);
   color: var(--text-primary);
 }
 
-.auth-type-selector label:has(input:checked) {
+.option-selector label:has(input:checked),
+.option-selector button.active {
   background: var(--accent-primary);
   border-color: var(--accent-primary);
   color: white;
   box-shadow: 0 1px 3px rgba(14, 165, 233, 0.3);
 }
 
-.auth-type-selector label:has(input:checked):hover {
+.option-selector label:has(input:checked):hover,
+.option-selector button.active:hover {
   background: var(--accent-primary-hover);
   border-color: var(--accent-primary-hover);
 }
 
-.auth-type-selector input[type="radio"] {
+.option-selector input[type="radio"] {
   position: absolute;
   opacity: 0;
   width: 0;

--- a/src/components/CollectionEditor.jsx
+++ b/src/components/CollectionEditor.jsx
@@ -239,7 +239,7 @@ function AuthTab({ authType, authToken, onChange, canEdit, isFolder, activeEnvir
 
   return (
     <div className="auth-editor">
-      <div className="auth-type-selector">
+      <div className="option-selector auth-type-selector">
         <label>
           <input
             type="radio"

--- a/src/components/RequestBodyEditor.jsx
+++ b/src/components/RequestBodyEditor.jsx
@@ -69,7 +69,7 @@ export function RequestBodyEditor({
 
   return (
     <div className="body-editor">
-      <div className="body-type-selector">
+      <div className="option-selector body-type-selector">
         {['none', 'form-data', 'json', 'raw'].map(type => (
           <label key={type}>
             <input

--- a/src/components/RequestEditor.jsx
+++ b/src/components/RequestEditor.jsx
@@ -700,7 +700,7 @@ export function RequestEditor({
 
         {activeDetailTab === 'auth' && (
           <div className="auth-editor">
-            <div className="auth-type-selector">
+            <div className="option-selector auth-type-selector">
               <label>
                 <input
                   type="radio"

--- a/src/components/ResponseViewer.jsx
+++ b/src/components/ResponseViewer.jsx
@@ -1,7 +1,14 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Monitor, Download, Terminal } from 'lucide-react';
 import JsonView from '@uiw/react-json-view';
 import { JsonEditor } from './JsonEditor';
+
+const isHtmlResponse = (headers) => {
+  if (!Array.isArray(headers)) return false;
+  return headers.some(
+    (h) => h.key?.toLowerCase() === 'content-type' && h.value?.includes('text/html')
+  );
+};
 
 const isTauri = () => '__TAURI_INTERNALS__' in window;
 
@@ -29,9 +36,15 @@ const isLocalOrPrivateUrl = (url) => {
 
 export function ResponseViewer({ response, loading, isExample, example, onExampleChange, requestUrl }) {
   const [activeTab, setActiveTab] = useState('body');
+  const [htmlViewMode, setHtmlViewMode] = useState('preview');
 
   // For examples, use example.response_data
   const displayResponse = isExample ? example?.response_data : response;
+
+  // Reset htmlViewMode to 'preview' when displayResponse changes
+  useEffect(() => {
+    setHtmlViewMode('preview');
+  }, [displayResponse]);
 
   // Parse JSON body - must be before any early returns!
   const jsonBody = useMemo(() => {
@@ -48,6 +61,10 @@ export function ResponseViewer({ response, loading, isExample, example, onExampl
   }, [displayResponse?.body]);
 
   const isJsonBody = jsonBody !== null;
+
+  const isHtmlBody = useMemo(() => {
+    return !isExample && !isJsonBody && isHtmlResponse(displayResponse?.headers);
+  }, [isExample, isJsonBody, displayResponse?.headers]);
 
   if (loading) {
     return (
@@ -225,6 +242,36 @@ export function ResponseViewer({ response, loading, isExample, example, onExampl
               showBeautify={true}
               className="response-json-editor"
             />
+          ) : isHtmlBody ? (
+            <>
+              <div className="option-selector html-view-toggle" data-testid="html-view-toggle">
+                <button
+                  className={htmlViewMode === 'preview' ? 'active' : ''}
+                  onClick={() => setHtmlViewMode('preview')}
+                  data-testid="html-preview-btn"
+                >
+                  Preview
+                </button>
+                <button
+                  className={htmlViewMode === 'raw' ? 'active' : ''}
+                  onClick={() => setHtmlViewMode('raw')}
+                  data-testid="html-raw-btn"
+                >
+                  Raw
+                </button>
+              </div>
+              {htmlViewMode === 'preview' ? (
+                <iframe
+                  className="html-preview-frame"
+                  srcDoc={displayResponse?.body}
+                  sandbox=""
+                  data-testid="html-preview-frame"
+                  title="HTML Preview"
+                />
+              ) : (
+                <pre className="response-body" data-testid="html-raw-body">{displayResponse?.body}</pre>
+              )}
+            </>
           ) : isJsonBody ? (
             <div className="json-view-wrapper">
               <JsonView

--- a/src/styles/request-editor.css
+++ b/src/styles/request-editor.css
@@ -800,53 +800,7 @@
    Body Type Selector - Segmented Control
    ============================================ */
 .body-type-selector {
-  display: flex;
-  align-items: center;
-  gap: 12px;
   margin-bottom: 12px;
-  flex-shrink: 0;
-}
-
-.body-type-selector label {
-  position: relative;
-  display: flex;
-  align-items: center;
-  padding: 2px 16px;
-  background: transparent;
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  user-select: none;
-}
-
-.body-type-selector label:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-secondary);
-  color: var(--text-primary);
-}
-
-.body-type-selector label:has(input:checked) {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
-  color: white;
-  box-shadow: 0 1px 3px rgba(14, 165, 233, 0.3);
-}
-
-.body-type-selector label:has(input:checked):hover {
-  background: var(--accent-primary-hover);
-  border-color: var(--accent-primary-hover);
-}
-
-.body-type-selector input[type="radio"] {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-  pointer-events: none;
 }
 
 .body-textarea {

--- a/src/styles/response-viewer.css
+++ b/src/styles/response-viewer.css
@@ -188,6 +188,21 @@
   color: var(--text-primary);
 }
 
+/* HTML Preview Toggle */
+.html-view-toggle {
+  margin-bottom: var(--space-3);
+}
+
+/* HTML Preview iframe */
+.html-preview-frame {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: #ffffff;
+}
+
 /* Desktop Agent Banner (shown when local URL fails on web) */
 .desktop-agent-banner {
   display: flex;


### PR DESCRIPTION
## Summary
- Detect `Content-Type: text/html` responses and render a sandboxed iframe preview in the Response Viewer
- Add Preview/Raw toggle to switch between rendered HTML and source code views
- Unify `.option-selector` pill-style CSS across body type, auth type, and HTML view toggle components
- JSON responses take priority over HTML detection; example mode is unaffected

## Test plan
- [x] FE-001: HTML response shows rendered preview in iframe with Preview button active
- [x] FE-002: Clicking Raw button hides iframe and shows raw HTML source
- [x] FE-003: Clicking Preview after Raw re-shows iframe
- [x] FE-004: JSON response shows JSON tree view with no HTML toggle
- [x] FE-005: HTML Content-Type with valid JSON body shows JSON tree (JSON priority)
- [x] FE-006: Example mode with HTML body shows JsonEditor, no iframe preview
- [x] No regressions in existing test suite (46/46 pass)

Closes #9