### PR TITLE
feat: error boundary, App/Sidebar refactor, drag-drop fix

### DIFF
--- a/acceptance/error-boundary.md
+++ b/acceptance/error-boundary.md
@@ -1,0 +1,63 @@
+# Acceptance Spec: Error Boundary
+
+## Feature
+Global React error boundary + WebSocket connection status indicator.
+
+## Components
+
+### 1. ErrorBoundary (class component)
+- **Location:** `src/components/ErrorBoundary.jsx`
+- Wraps `<App />` in `main.jsx`
+- Catches render errors via `componentDidCatch`
+- Fallback UI:
+  - Centered card with error icon, "Something went wrong" heading
+  - "Reload" button that calls `window.location.reload()`
+  - In development: show component stack trace
+- `data-testid="error-boundary-fallback"` on the fallback root
+- `data-testid="error-boundary-reload"` on the reload button
+- Matches the app's design system (CSS variables, fonts)
+
+### 2. ConnectionStatus indicator
+- **Location:** `src/components/ConnectionStatus.jsx`
+- Renders a slim banner at the top of the app when disconnected/reconnecting
+- States: `connected` (hidden), `reconnecting` (yellow banner), `disconnected` (red banner)
+- `data-testid="connection-status"` on the banner
+- Auto-hides 2 seconds after reconnection succeeds
+
+### 3. useWebSocket changes
+- **File:** `src/hooks/useWebSocket.js`
+- Expose connection status: `{ connected, reconnecting }`
+- Return object instead of just wsRef
+- Track state transitions: connected → disconnected → reconnecting → connected
+
+## Interface Contract
+
+```jsx
+// ErrorBoundary
+<ErrorBoundary>
+  <App />
+</ErrorBoundary>
+
+// ConnectionStatus — used inside AppContent
+<ConnectionStatus connected={wsConnected} reconnecting={wsReconnecting} />
+
+// useWebSocket — updated return value
+const { wsRef, connected, reconnecting } = useWebSocket(onMessage);
+```
+
+## Business Rules
+- ErrorBoundary only catches React render errors (not async/event handler errors)
+- Connection banner must not block interaction (position: sticky or fixed, small height)
+- Banner shows "Reconnecting..." with subtle animation when reconnecting
+- Banner shows "Connection lost" when disconnected for >5 seconds
+- When connection restores, banner briefly shows "Connected" then fades out
+
+## Test IDs
+- `error-boundary-fallback` — fallback UI root
+- `error-boundary-reload` — reload button
+- `connection-status` — connection banner
+
+## Out of Scope
+- Supabase API error message improvements (separate concern)
+- Error logging/telemetry service
+- Retry logic for failed API calls

--- a/e2e/advanced-operations.spec.ts
+++ b/e2e/advanced-operations.spec.ts
@@ -1,16 +1,64 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { cleanupTestCollections } from './helpers/cleanup';
 
-// Generate unique names for each test run
 const timestamp = Date.now();
 const uniqueName = (base: string) => `${base} ${timestamp}`;
 
 test.afterAll(async () => { await cleanupTestCollections(timestamp); });
 
+// Run tests serially — drag-and-drop is sensitive to sidebar element positions
+test.describe.configure({ mode: 'serial' });
+
+/** Create a collection via sidebar and return its header locator */
+async function createCollection(page: Page, name: string) {
+  const addBtn = page.locator('.sidebar-toolbar .btn-icon').last();
+  await addBtn.click();
+  const modal = page.locator('.prompt-modal');
+  await expect(modal).toBeVisible();
+  await modal.locator('.prompt-input').fill(name);
+  await modal.locator('.prompt-btn-confirm').click();
+  await expect(modal).not.toBeVisible();
+  const header = page.locator('.collection-header').filter({ hasText: name });
+  await expect(header).toBeVisible({ timeout: 5000 });
+  return header;
+}
+
+/** Add a request to a collection via context menu */
+async function addRequest(page: Page, collectionHeader: ReturnType<Page['locator']>) {
+  await collectionHeader.hover();
+  await collectionHeader.locator('.btn-menu').click();
+  const menu = page.locator('.collection-menu');
+  await expect(menu).toBeVisible();
+  await menu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+  await page.waitForTimeout(500);
+}
+
+/** Get ordered request names inside a collection */
+async function getRequestNames(page: Page, collectionName: string): Promise<string[]> {
+  const collection = page.locator('.collection').filter({
+    has: page.locator('.collection-header').filter({ hasText: collectionName }),
+  });
+  const names = await collection.locator('.request-item .request-name').allTextContents();
+  return names;
+}
+
+/** Rename the currently selected request via its tab */
+async function renameRequestViaMenu(page: Page, requestItem: ReturnType<Page['locator']>, newName: string) {
+  await requestItem.hover();
+  await requestItem.locator('.btn-menu').click();
+  const menu = page.locator('.request-menu').last();
+  await expect(menu).toBeVisible();
+  await menu.locator('.request-menu-item').filter({ hasText: 'Rename' }).click();
+  const input = requestItem.locator('.rename-input');
+  await expect(input).toBeVisible();
+  await input.fill(newName);
+  await input.press('Enter');
+  await page.waitForTimeout(300);
+}
+
 test.describe('Advanced Operations', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    // Wait for app to finish loading
     await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
     await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
@@ -18,118 +66,106 @@ test.describe('Advanced Operations', () => {
     await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
   });
 
-  // "Move to" menu item was replaced by drag-and-drop in sidebar
-  test.fixme('user can move a request to a different collection', async ({ page }) => {
-    // Create two collections
-    const sourceCollectionName = uniqueName('Source Collection');
-    const targetCollectionName = uniqueName('Target Collection');
+  test('user can reorder requests via drag and drop', async ({ page }) => {
+    const collectionName = uniqueName('DnD Reorder');
+    const collectionHeader = await createCollection(page, collectionName);
 
-    // Create source collection
-    const addCollectionBtn = page.locator('.sidebar-toolbar .btn-icon').last();
-    await addCollectionBtn.click();
-    let promptModal = page.locator('.prompt-modal');
-    await expect(promptModal).toBeVisible();
-    await promptModal.locator('.prompt-input').fill(sourceCollectionName);
-    await promptModal.locator('.prompt-btn-confirm').click();
-    await expect(promptModal).not.toBeVisible();
+    // Create 3 requests
+    await addRequest(page, collectionHeader);
+    await addRequest(page, collectionHeader);
+    await addRequest(page, collectionHeader);
 
-    // Create target collection
-    await addCollectionBtn.click();
-    promptModal = page.locator('.prompt-modal');
-    await expect(promptModal).toBeVisible();
-    await promptModal.locator('.prompt-input').fill(targetCollectionName);
-    await promptModal.locator('.prompt-btn-confirm').click();
-    await expect(promptModal).not.toBeVisible();
+    // Rename them to A, B, C so we can track order
+    const collection = page.locator('.collection').filter({
+      has: page.locator('.collection-header').filter({ hasText: collectionName }),
+    });
+    const requests = collection.locator('.request-item');
+    await expect(requests).toHaveCount(3, { timeout: 5000 });
 
-    // Add a request to source collection
-    const sourceCollectionHeader = page.locator('.collection-header').filter({ hasText: sourceCollectionName });
-    await expect(sourceCollectionHeader).toBeVisible({ timeout: 5000 });
-    await sourceCollectionHeader.hover();
-    await sourceCollectionHeader.locator('.btn-menu').click();
+    await renameRequestViaMenu(page, requests.nth(0), 'Req-A');
+    await renameRequestViaMenu(page, requests.nth(1), 'Req-B');
+    await renameRequestViaMenu(page, requests.nth(2), 'Req-C');
 
-    let collectionMenu = page.locator('.collection-menu');
-    await expect(collectionMenu).toBeVisible();
-    await collectionMenu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+    // Verify initial order
+    let names = await getRequestNames(page, collectionName);
+    expect(names).toEqual(['Req-A', 'Req-B', 'Req-C']);
 
-    // Wait for request to appear in source collection
-    const requestItem = page.locator('.request-item').filter({ hasText: 'New Request' }).first();
-    await expect(requestItem).toBeVisible({ timeout: 5000 });
+    // Drag C onto A (C should move before A → C, A, B)
+    const reqC = collection.locator('.request-item').filter({ hasText: 'Req-C' });
+    const reqA = collection.locator('.request-item').filter({ hasText: 'Req-A' });
+    await reqC.dragTo(reqA);
 
-    // Open request context menu and click "Move to..."
-    await requestItem.hover();
-    const requestMoreBtn = requestItem.locator('.btn-menu');
-    await expect(requestMoreBtn).toBeVisible();
-    await requestMoreBtn.click();
+    // Wait for optimistic update
+    await page.waitForTimeout(500);
 
-    const requestMenu = page.locator('.request-menu').filter({ has: page.locator('button').filter({ hasText: 'Move to' }) });
-    await expect(requestMenu).toBeVisible();
-    await requestMenu.locator('.request-menu-item').filter({ hasText: 'Move to' }).click();
+    // Verify new order
+    names = await getRequestNames(page, collectionName);
+    expect(names).toEqual(['Req-C', 'Req-A', 'Req-B']);
+  });
 
-    // Move modal should appear
-    const moveModal = page.locator('.move-to-modal');
-    await expect(moveModal).toBeVisible({ timeout: 5000 });
+  test('user can move request into a subfolder via drag and drop', async ({ page }) => {
+    const collectionName = uniqueName('DnD Move');
+    const folderName = uniqueName('DnD Subfolder');
 
-    // Select target collection
-    const targetFolder = moveModal.locator('.move-to-folder-item').filter({ hasText: targetCollectionName });
-    await expect(targetFolder).toBeVisible();
-    await targetFolder.click();
+    const collectionHeader = await createCollection(page, collectionName);
 
-    // Click Move button
-    await moveModal.locator('.btn-primary').filter({ hasText: 'Move' }).click();
+    // Add a request to the root collection
+    await addRequest(page, collectionHeader);
+    const rootCollection = page.locator('.collection').filter({
+      has: page.locator('.collection-header').filter({ hasText: collectionName }),
+    });
+    await expect(rootCollection.locator('.request-item')).toHaveCount(1, { timeout: 5000 });
 
-    // Modal should close
-    await expect(moveModal).not.toBeVisible({ timeout: 5000 });
+    // Create a subfolder via context menu
+    await collectionHeader.hover();
+    await collectionHeader.locator('.btn-menu').click();
+    const menu = page.locator('.collection-menu');
+    await expect(menu).toBeVisible();
+    await menu.locator('.request-menu-item').filter({ hasText: 'Add Folder' }).click();
+    const folderPrompt = page.locator('.prompt-modal');
+    await expect(folderPrompt).toBeVisible();
+    await folderPrompt.locator('.prompt-input').fill(folderName);
+    await folderPrompt.locator('.prompt-btn-confirm').click();
+    await expect(folderPrompt).not.toBeVisible();
 
-    // Expand target collection to see the moved request
-    const targetCollectionHeader = page.locator('.collection-header').filter({ hasText: targetCollectionName });
-    await targetCollectionHeader.click();
+    const folderHeader = page.locator('.collection-header').filter({ hasText: folderName });
+    await expect(folderHeader).toBeVisible({ timeout: 5000 });
 
-    // Verify request is now in target collection
-    // The request should be visible under the target collection
-    await expect(page.locator('.collection').filter({ has: targetCollectionHeader }).locator('.request-item').filter({ hasText: 'New Request' })).toBeVisible({ timeout: 5000 });
+    // Drag the request onto the subfolder header
+    const request = rootCollection.locator('.request-item').first();
+    await request.dragTo(folderHeader);
 
-    await page.screenshot({ path: 'e2e/screenshots/request-moved.png' });
+    await page.waitForTimeout(500);
+
+    // Request should appear inside the subfolder (expand it first)
+    await folderHeader.click();
+    const subfolder = page.locator('.collection').filter({
+      has: page.locator('.collection-header').filter({ hasText: folderName }),
+    });
+    await expect(subfolder.locator('.request-item')).toHaveCount(1, { timeout: 5000 });
   });
 
   test('user can create nested sub-collections', async ({ page }) => {
     const parentCollectionName = uniqueName('Parent Collection');
     const childCollectionName = uniqueName('Child Folder');
 
-    // Create parent collection
-    const addCollectionBtn = page.locator('.sidebar-toolbar .btn-icon').last();
-    await addCollectionBtn.click();
-    const promptModal = page.locator('.prompt-modal');
-    await expect(promptModal).toBeVisible();
-    await promptModal.locator('.prompt-input').fill(parentCollectionName);
-    await promptModal.locator('.prompt-btn-confirm').click();
-    await expect(promptModal).not.toBeVisible();
+    const parentCollectionHeader = await createCollection(page, parentCollectionName);
 
-    // Find parent collection and open context menu
-    const parentCollectionHeader = page.locator('.collection-header').filter({ hasText: parentCollectionName });
-    await expect(parentCollectionHeader).toBeVisible({ timeout: 5000 });
+    // Open context menu and add folder
     await parentCollectionHeader.hover();
     await parentCollectionHeader.locator('.btn-menu').click();
-
-    // Click "Add Folder" to create a sub-collection
     const collectionMenu = page.locator('.collection-menu');
     await expect(collectionMenu).toBeVisible();
     await collectionMenu.locator('.request-menu-item').filter({ hasText: 'Add Folder' }).click();
 
-    // Enter name for sub-collection
     const folderPrompt = page.locator('.prompt-modal');
     await expect(folderPrompt).toBeVisible({ timeout: 5000 });
     await folderPrompt.locator('.prompt-input').fill(childCollectionName);
     await folderPrompt.locator('.prompt-btn-confirm').click();
     await expect(folderPrompt).not.toBeVisible();
 
-    // Parent collection should now be expanded showing the child folder
-    // The child folder should have a folder icon and be indented
     const childCollectionHeader = page.locator('.collection-header').filter({ hasText: childCollectionName });
     await expect(childCollectionHeader).toBeVisible({ timeout: 5000 });
-
-    // Verify child has the folder icon (indicating it's a sub-folder)
     await expect(childCollectionHeader.locator('.folder-icon')).toBeVisible();
-
-    await page.screenshot({ path: 'e2e/screenshots/collection-nested.png' });
   });
 });

--- a/e2e/error-boundary.spec.ts
+++ b/e2e/error-boundary.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('ErrorBoundary and ConnectionStatus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+  });
+
+  test('EB-001: error boundary fallback is not visible during normal operation', async ({ page }) => {
+    // The fallback UI should not be present when the app renders without errors
+    const fallback = page.locator('[data-testid="error-boundary-fallback"]');
+    await expect(fallback).not.toBeVisible();
+  });
+
+  test('EB-002: connection status banner is hidden when connected', async ({ page }) => {
+    // The connection status banner should not be visible (or not in DOM) when WebSocket is connected
+    const banner = page.locator('[data-testid="connection-status"]');
+
+    const count = await banner.count();
+    if (count > 0) {
+      await expect(banner).not.toBeVisible();
+    }
+    // If the element is not in the DOM at all, that also satisfies the requirement
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,9 +3459,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4046,9 +4046,9 @@
       "license": "MIT"
     },
     "node_modules/supabase": {
-      "version": "2.84.6",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.84.6.tgz",
-      "integrity": "sha512-JCot1xBtDPzt5Cplr5yOoPuKsag98azw/kITMvzABO6fF7cTj9bX9qWbkTcAaV2iCnmnI6rXesla3WtamZ4Iag==",
+      "version": "2.84.7",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.84.7.tgz",
+      "integrity": "sha512-s3tA5U3U1Wr4OH4dNn/phDk3+kjgOaDs7Q86rSKvkZK14qsy00t4w5r6yn3jxQBC23mQ95lzfMvpSzI+WXcDbQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,8 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { isEqual, pick } from 'lodash-es';
-import { Copy, X } from 'lucide-react';
-import CodeMirror from '@uiw/react-codemirror';
-import { StreamLanguage } from '@codemirror/language';
-import { shell } from '@codemirror/legacy-modes/mode/shell';
-import { EditorView } from '@codemirror/view';
+import { useState, useEffect, useCallback } from 'react';
 import { AuthCallback } from './components/AuthCallback';
 import { Login } from './components/Login';
 import { Sidebar } from './components/Sidebar';
-import { RequestEditor, generateCurl } from './components/RequestEditor';
+import { RequestEditor } from './components/RequestEditor';
 import { ResponseViewer } from './components/ResponseViewer';
 import { AppModals } from './components/AppModals';
 import { CollectionEditor } from './components/CollectionEditor';
@@ -16,6 +10,7 @@ import { CollectionDocs } from './components/CollectionDocs';
 import { WorkflowEditor } from './components/WorkflowEditor';
 import { VariablePopoverProvider } from './components/VariablePopover';
 import { AppHeader } from './components/AppHeader';
+import { syncCloseBehaviorToRust } from './components/SettingsModal';
 import { TabBar } from './components/TabBar';
 import { useToast } from './components/Toast';
 import { useConfirm } from './components/ConfirmModal';
@@ -23,9 +18,14 @@ import { usePrompt } from './components/PromptModal';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { WorkbenchProvider, useWorkbench } from './contexts/WorkbenchContext';
 import { WorkspaceProvider, useWorkspace } from './contexts/WorkspaceContext';
-import { useWebSocket } from './hooks/useWebSocket';
+import { CurlPanel } from './components/CurlPanel';
+import { ConnectionStatus } from './components/ConnectionStatus';
+import { useRealtimeSync } from './hooks/useRealtimeSync';
 import { useLayoutState } from './hooks/useLayoutState';
 import { useVersionCheck } from './hooks/useVersionCheck';
+import { useClipboardLinks } from './hooks/useClipboardLinks';
+import { useCollectionVariables } from './hooks/useCollectionVariables';
+import { useTauriClose } from './hooks/useTauriClose';
 import * as data from './data/index.js';
 import './App.css';
 import './styles/sidebar.css';
@@ -39,170 +39,27 @@ import './styles/environment-editor.css';
 import './styles/presence-avatars.css';
 import './styles/workflow-editor.css';
 import './styles/collection-docs.css';
+import './styles/error-boundary.css';
 
-import { METHOD_COLORS } from './constants/methodColors';
-
-function sortRequests(requests) {
-  return [...requests].sort((a, b) => {
-    const sortA = a.sort_order ?? Number.MAX_SAFE_INTEGER;
-    const sortB = b.sort_order ?? Number.MAX_SAFE_INTEGER;
-    if (sortA !== sortB) return sortA - sortB;
-    return (a.created_at || 0) - (b.created_at || 0);
-  });
-}
-
-function upsertCollectionInState(collections, collection) {
-  const existing = collections.find((item) => item.id === collection.id);
-  const nextCollection = {
-    ...existing,
-    ...collection,
-    requests: existing?.requests || [],
-  };
-
-  if (existing) {
-    return collections.map((item) => (item.id === collection.id ? nextCollection : item));
-  }
-
-  return [...collections, nextCollection].sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
-}
-
-function removeCollectionBranch(collections, collectionId) {
-  const idsToRemove = new Set([collectionId]);
-  let changed = true;
-
-  while (changed) {
-    changed = false;
-    collections.forEach((collection) => {
-      if (collection.parent_id && idsToRemove.has(collection.parent_id) && !idsToRemove.has(collection.id)) {
-        idsToRemove.add(collection.id);
-        changed = true;
-      }
-    });
-  }
-
-  return collections.filter((collection) => !idsToRemove.has(collection.id));
-}
-
-function upsertRequestInState(collections, request) {
-  let existingRequest = null;
-
-  const collectionsWithoutRequest = collections.map((collection) => ({
-    ...collection,
-    requests: (collection.requests || []).filter((item) => {
-      if (item.id === request.id) {
-        existingRequest = item;
-        return false;
-      }
-      return true;
-    }),
-  }));
-
-  return collectionsWithoutRequest.map((collection) => {
-    if (collection.id !== request.collection_id) {
-      return collection;
-    }
-
-    const nextRequest = {
-      ...existingRequest,
-      ...request,
-      example_count: request.example_count ?? existingRequest?.example_count ?? 0,
-    };
-
-    return {
-      ...collection,
-      requests: sortRequests([...(collection.requests || []), nextRequest]),
-    };
-  });
-}
-
-function removeRequestFromState(collections, requestId) {
-  return collections.map((collection) => ({
-    ...collection,
-    requests: (collection.requests || []).filter((request) => request.id !== requestId),
-  }));
-}
-
-function patchRequestInState(collections, requestId, updater) {
-  return collections.map((collection) => ({
-    ...collection,
-    requests: (collection.requests || []).map((request) => (
-      request.id === requestId ? updater(request) : request
-    )),
-  }));
-}
-
-function upsertExampleInList(examples, example) {
-  const existing = examples.find((item) => item.id === example.id);
-  if (existing) {
-    return examples.map((item) => (item.id === example.id ? { ...item, ...example } : item));
-  }
-
-  return [example, ...examples].sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
-}
-
-const curlEditorTheme = EditorView.theme({
-  '&': {
-    backgroundColor: 'transparent',
-    color: 'var(--text-primary)',
-    fontSize: '12px',
-    fontFamily: 'var(--font-mono)',
-    height: '100%',
-  },
-  '.cm-content': {
-    padding: '14px 4px',
-    caretColor: 'transparent',
-  },
-  '.cm-cursor': { display: 'none' },
-  '.cm-activeLine': { backgroundColor: 'transparent' },
-  '&.cm-focused .cm-activeLine': { backgroundColor: 'transparent' },
-  '.cm-gutters': {
-    backgroundColor: 'transparent',
-    color: 'var(--text-tertiary)',
-    border: 'none',
-    borderRight: '1px solid var(--border-subtle)',
-  },
-  '.cm-activeLineGutter': { backgroundColor: 'transparent' },
-  '&.cm-focused .cm-activeLineGutter': { backgroundColor: 'transparent' },
-  '.cm-lineNumbers .cm-gutterElement': {
-    padding: '0 8px 0 12px',
-    minWidth: '28px',
-    fontSize: '11px',
-  },
-  '.cm-scroller': {
-    fontFamily: 'var(--font-mono)',
-    lineHeight: '1.7',
-    overflow: 'auto',
-  },
-  '&.cm-focused': { outline: 'none' },
-  '.cm-selectionBackground': { backgroundColor: 'rgba(59, 130, 246, 0.2) !important' },
-  '&.cm-focused .cm-selectionBackground': { backgroundColor: 'rgba(59, 130, 246, 0.3) !important' },
-});
-
-const curlLightSyntax = EditorView.theme({
-  '.ͼd': { color: '#16a34a' },  // strings
-  '.ͼc': { color: '#d97706' },  // numbers
-  '.ͼb': { color: '#0284c7' },  // keywords (curl, flags)
-  '.ͼe': { color: '#7c3aed' },  // builtins
-});
-
-const curlDarkSyntax = EditorView.theme({
-  '.ͼd': { color: '#4ade80' },  // strings
-  '.ͼc': { color: '#fbbf24' },  // numbers
-  '.ͼb': { color: '#38bdf8' },  // keywords
-  '.ͼe': { color: '#a78bfa' },  // builtins
-});
-
-const shellLang = StreamLanguage.define(shell);
+import useModalStore from './stores/modalStore';
 
 function AppContent() {
-  const [showEnvEditor, setShowEnvEditor] = useState(false);
-  const [showImportCurl, setShowImportCurl] = useState(false);
-  const [draftSavePending, setDraftSavePending] = useState(null);
-  const [tempCloseTabId, setTempCloseTabId] = useState(null);
-  const [dirtyCloseTabId, setDirtyCloseTabId] = useState(null);
-  const [showSettings, setShowSettings] = useState(false);
-  const [showAbout, setShowAbout] = useState(false);
-  const [showCloseModal, setShowCloseModal] = useState(false);
+  const showEnvEditor = useModalStore((s) => s.showEnvEditor);
+  const setShowEnvEditor = useModalStore((s) => s.setShowEnvEditor);
+  const showImportCurl = useModalStore((s) => s.showImportCurl);
+  const setShowImportCurl = useModalStore((s) => s.setShowImportCurl);
+  const draftSavePending = useModalStore((s) => s.draftSavePending);
+  const setDraftSavePending = useModalStore((s) => s.setDraftSavePending);
+  const tempCloseTabId = useModalStore((s) => s.tempCloseTabId);
+  const setTempCloseTabId = useModalStore((s) => s.setTempCloseTabId);
+  const dirtyCloseTabId = useModalStore((s) => s.dirtyCloseTabId);
+  const setDirtyCloseTabId = useModalStore((s) => s.setDirtyCloseTabId);
+  const showSettings = useModalStore((s) => s.showSettings);
+  const setShowSettings = useModalStore((s) => s.setShowSettings);
+  const showAbout = useModalStore((s) => s.showAbout);
+  const setShowAbout = useModalStore((s) => s.setShowAbout);
+  const showCloseModal = useModalStore((s) => s.showCloseModal);
+  const setShowCloseModal = useModalStore((s) => s.setShowCloseModal);
   const [userConfig, setUserConfig] = useState({});
   const toast = useToast();
   const { updateAvailable, tauriUpdate, downloading, downloadProgress, installUpdate, checkForUpdate, checking, isTauri } = useVersionCheck();
@@ -221,8 +78,6 @@ function AppContent() {
     toggleCurlPanel,
   } = useLayoutState();
 
-  const userRef = useRef(null);
-  const closeBehaviorRef = useRef(null);
   const {
     user,
     authChecked,
@@ -244,34 +99,7 @@ function AppContent() {
     }).catch(() => {});
   }, [user, handleThemeChange]);
 
-  useEffect(() => { userRef.current = user; }, [user]);
-  useEffect(() => { closeBehaviorRef.current = userConfig.closeBehavior; }, [userConfig]);
-
-  // Listen for Tauri close-requested event (when no preference is saved)
-  useEffect(() => {
-    if (!('__TAURI_INTERNALS__' in window)) return;
-    let unlisten;
-    let cancelled = false;
-    import('@tauri-apps/api/event').then(({ listen }) => {
-      if (cancelled) return;
-      listen('close-requested', async () => {
-        const { invoke } = await import('@tauri-apps/api/core');
-        if (!userRef.current) {
-          await invoke('close_app');
-        } else {
-          const behavior = closeBehaviorRef.current;
-          if (behavior === 'tray') {
-            await invoke('hide_window');
-          } else if (behavior === 'close') {
-            await invoke('close_app');
-          } else {
-            setShowCloseModal(true);
-          }
-        }
-      }).then(fn => { if (!cancelled) unlisten = fn; else fn(); });
-    });
-    return () => { cancelled = true; unlisten?.(); };
-  }, []);
+  useTauriClose(userConfig);
 
   const {
     activeWorkspace,
@@ -302,9 +130,7 @@ function AppContent() {
     activeTabId,
     setActiveTabId,
     conflictedTabs,
-    setConflictedTabs,
     deletedTabs,
-    setDeletedTabs,
     previewTabId,
     pendingRequestIds,
     pendingExampleIds,
@@ -321,12 +147,9 @@ function AppContent() {
     collections,
     setCollections,
     collectionsLoading,
-    examples,
-    setExamples,
     environments,
     activeEnvironment,
     setActiveEnvironment,
-    loadCollections,
     loadEnvironments,
     loading,
     closeTab,
@@ -364,10 +187,8 @@ function AppContent() {
     updateTabCollection,
     handleSaveCollection,
     updateActiveDetailTab,
-    wasRecentlyModified,
     openCollectionInTab,
     openRequestInTab,
-    openExampleInTab,
     saveFunctionsRef,
     workflows,
     loadWorkflows,
@@ -377,145 +198,11 @@ function AppContent() {
     handleSaveWorkflow,
   } = useWorkbench();
 
-  const lastClipboardLinkRef = useRef(null);
-
-  useEffect(() => {
-    if (!user) return;
-    const baseUrl = import.meta.env.VITE_APP_URL || window.location.origin;
-    const pattern = new RegExp(
-      `^${baseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/\\?.*type=(collection|folder|request|example)&id=([0-9a-f-]+)`
-    );
-
-    const handleFocus = async () => {
-      let text;
-      try {
-        text = await navigator.clipboard.readText();
-      } catch {
-        return;
-      }
-      if (!text) return;
-      const match = text.match(pattern);
-      if (!match) return;
-      const type = match[1];
-      const id = match[2];
-
-      const urlParams = new URLSearchParams(text.split('?')[1]);
-      const uid = urlParams.get('uid');
-      if (uid && uid === String(user.id)) return;
-
-      if (text === lastClipboardLinkRef.current) return;
-      lastClipboardLinkRef.current = text;
-
-      if (type === 'collection' || type === 'folder') {
-        const found = collections.find(c => c.id === id);
-        if (!found) return;
-        toast.action(`Open shared ${type}?`, {
-          label: 'Open',
-          onClick: () => {
-            openCollectionInTab(found, { replacePreview: false });
-            setRevealCollectionId(id);
-          },
-        });
-      } else if (type === 'request') {
-        let request = null;
-        for (const c of collections) {
-          request = c.requests?.find(r => r.id === id);
-          if (request) break;
-        }
-        if (!request) return;
-        toast.action('Open shared request?', {
-          label: 'Open',
-          onClick: async () => {
-            const fullRequest = await data.getRequest(id);
-            openRequestInTab(fullRequest, { replacePreview: false });
-            setRevealRequestId(id);
-          },
-        });
-      } else if (type === 'example') {
-        toast.action('Open shared example?', {
-          label: 'Open',
-          onClick: async () => {
-            try {
-              const example = await data.getExample(id);
-              const parentRequest = await data.getRequest(example.request_id);
-              openExampleInTab(example, parentRequest, { replacePreview: false });
-              setRevealRequestId(parentRequest.id);
-            } catch {
-              toast.error('Failed to open shared example.');
-            }
-          },
-        });
-      }
-    };
-
-    window.addEventListener('focus', handleFocus);
-    return () => window.removeEventListener('focus', handleFocus);
-  }, [user, collections, toast, openCollectionInTab, openRequestInTab, openExampleInTab, setRevealCollectionId, setRevealRequestId]);
+  useClipboardLinks();
 
   const canEdit = ['system', 'admin', 'developer'].includes(userProfile?.role);
 
-  // Load collection variables for the active request/collection's root collection
-  const [collectionVariables, setCollectionVariables] = useState([]);
-
-  const activeCollectionId = useMemo(() => {
-    if (activeTab?.type === 'collection') return activeTab.collection?.id;
-    if (selectedRequest?.collection_id) return selectedRequest.collection_id;
-    return null;
-  }, [activeTab?.type, activeTab?.collection?.id, selectedRequest?.collection_id]);
-
-  const rootCollectionId = useMemo(() => {
-    if (!activeCollectionId || !collections) return null;
-    let currentId = activeCollectionId;
-    let iterations = 0;
-    while (currentId && iterations < 50) {
-      const col = collections.find(c => c.id === currentId);
-      if (!col) break;
-      if (!col.parent_id) return col.id;
-      currentId = col.parent_id;
-      iterations++;
-    }
-    return currentId;
-  }, [activeCollectionId, collections]);
-
-  const reloadCollectionVariables = useCallback(() => {
-    if (!rootCollectionId) return;
-    data.getCollectionVariables(rootCollectionId).then(setCollectionVariables).catch(() => setCollectionVariables([]));
-  }, [rootCollectionId]);
-
-  useEffect(() => {
-    if (!rootCollectionId) { setCollectionVariables([]); return; }
-    reloadCollectionVariables();
-  }, [rootCollectionId, reloadCollectionVariables]);
-
-  const curlPreview = useMemo(() => {
-    if (!showCurlPanel) return '';
-    const req = activeTab?.type === 'example'
-      ? selectedExample?.request_data
-      : selectedRequest;
-    if (!req) return '';
-    const sub = (text) => {
-      if (!text || !activeEnvironment) return text;
-      let result = text;
-      for (const v of activeEnvironment.variables) {
-        if (v.enabled && v.key) {
-          result = result.replace(new RegExp(`\\{\\{${v.key}\\}\\}`, 'g'), v.value || '');
-        }
-      }
-      return result;
-    };
-    const headers = (req.headers || []).map(h => ({ ...h, key: sub(h.key), value: sub(h.value) }));
-    const fd = (req.form_data || []).map(f => ({ ...f, key: sub(f.key), value: f.type === 'file' ? f.value : sub(f.value) }));
-    return generateCurl(
-      req.method || 'GET',
-      sub(req.url || ''),
-      headers,
-      sub(req.body || ''),
-      req.body_type || 'none',
-      fd,
-      req.auth_type || 'none',
-      sub(req.auth_token || '')
-    );
-  }, [showCurlPanel, selectedRequest, selectedExample, activeTab?.type, activeEnvironment]);
+  const { collectionVariables, rootCollectionId, onEnvironmentUpdate } = useCollectionVariables();
 
   // Register temp request save handler for Ctrl+S
   useEffect(() => {
@@ -544,285 +231,7 @@ function AppContent() {
     }
   }, [toast, user]);
 
-  const handleWebSocketMessage = useCallback(
-    (message) => {
-      const { event, data: payload } = message;
-
-      if (event === 'request:update' && payload?.id) {
-        const tabId = `request-${payload.id}`;
-        // Check if this is our own save or rename (ignore it)
-        if (wasRecentlyModified(tabId)) {
-          return;
-        }
-
-        // Check if this request is open in any tab (means user is working on it)
-        const openTab = openTabs.find(t => t.id === tabId);
-        if (openTab) {
-          // Only mark conflicted if content fields actually changed (not just sort_order/updated_at)
-          // Normalize JSON-string fields from Realtime payload to match parsed arrays in tab state
-          const parseJson = (v) => typeof v === 'string' ? JSON.parse(v || '[]') : (v || []);
-          const normalized = { ...payload, headers: parseJson(payload.headers), params: parseJson(payload.params), form_data: parseJson(payload.form_data) };
-          const requestContentFields = ['name', 'method', 'url', 'body', 'body_type', 'auth_type', 'auth_token', 'pre_script', 'post_script', 'headers', 'params', 'form_data'];
-          const contentChanged = openTab.request && !isEqual(pick(normalized, requestContentFields), pick(openTab.request, requestContentFields));
-
-          if (contentChanged) {
-            setConflictedTabs(prev => ({
-              ...prev,
-              [tabId]: payload
-            }));
-          }
-        }
-      }
-
-      if (event === 'request:create' && payload?.id) {
-        const tabId = `request-${payload.id}`;
-        if (wasRecentlyModified(tabId)) {
-          return;
-        }
-      }
-
-      if (event === 'example:update' && payload?.id) {
-        const tabId = `example-${payload.id}`;
-        // Check if this is our own save or rename (ignore it)
-        if (wasRecentlyModified(tabId)) {
-          return;
-        }
-
-        // Check if this example is open in any tab
-        const openTab = openTabs.find(t => t.id === tabId);
-        if (openTab) {
-          const exampleContentFields = ['name', 'request_data', 'response_data'];
-          const contentChanged = openTab.example && !isEqual(pick(payload, exampleContentFields), pick(openTab.example, exampleContentFields));
-
-          if (contentChanged) {
-            setConflictedTabs(prev => ({
-              ...prev,
-              [tabId]: payload
-            }));
-          }
-        }
-      }
-
-      if (event === 'example:create' && payload?.id) {
-        const tabId = `example-${payload.id}`;
-        if (wasRecentlyModified(tabId)) {
-          return;
-        }
-      }
-
-      // Handle request deletion - mark open tabs as deleted
-      if (event === 'request:delete' && payload?.id) {
-        const tabId = `request-${payload.id}`;
-        if (wasRecentlyModified(tabId)) {
-          return;
-        }
-        const openTab = openTabs.find(t => t.id === tabId);
-        if (openTab) {
-          setDeletedTabs(prev => new Set([...prev, tabId]));
-        }
-      }
-
-      // Handle example deletion - mark open tabs as deleted
-      if (event === 'example:delete' && payload?.id) {
-        const tabId = `example-${payload.id}`;
-        if (wasRecentlyModified(tabId)) {
-          return;
-        }
-        const openTab = openTabs.find(t => t.id === tabId);
-        if (openTab) {
-          setDeletedTabs(prev => new Set([...prev, tabId]));
-        }
-      }
-
-      // Check if this is our own collection modification (skip reload)
-      if (
-        (event === 'collection:create' || event === 'collection:update' || event === 'collection:delete') &&
-        payload?.id &&
-        wasRecentlyModified(`collection-${payload.id}`)
-      ) {
-        return;
-      }
-
-      // Check if this is our own request modification (skip reload)
-      if (
-        (event === 'request:create' || event === 'request:update' || event === 'request:delete') &&
-        payload?.id &&
-        wasRecentlyModified(`request-${payload.id}`)
-      ) {
-        return;
-      }
-
-      // Check if this is our own example modification (skip reload)
-      // Examples are deleted when their parent request is deleted
-      if (
-        (event === 'example:create' || event === 'example:update' || event === 'example:delete') &&
-        payload?.id &&
-        wasRecentlyModified(`example-${payload.id}`)
-      ) {
-        return;
-      }
-
-      // Also skip example events if the parent request was recently modified (cascade delete)
-      if (
-        (event === 'example:delete') &&
-        payload?.request_id &&
-        wasRecentlyModified(`request-${payload.request_id}`)
-      ) {
-        return;
-      }
-
-      // Check if this is our own import (skip reload)
-      if (event === 'sync:import' && payload?.rootCollectionId && wasRecentlyModified(`collection-${payload.rootCollectionId}`)) {
-        return;
-      }
-
-      // Handle delete events by updating state directly (no reload needed)
-      if (event === 'collection:delete' && payload?.id) {
-        setCollections(prev => removeCollectionBranch(prev, payload.id));
-        return;
-      }
-
-      if (event === 'request:delete' && payload?.id) {
-        setCollections(prev => removeRequestFromState(prev, payload.id));
-        return;
-      }
-
-      if (event === 'collection:create' && payload?.id) {
-        setCollections(prev => upsertCollectionInState(prev, payload));
-        return;
-      }
-
-      if (event === 'collection:update' && payload?.id) {
-        setCollections(prev => upsertCollectionInState(prev, payload));
-        return;
-      }
-
-      if ((event === 'request:create' || event === 'request:update' || event === 'request:move') && payload?.id) {
-        data.getRequest(payload.id)
-          .then((request) => {
-            setCollections(prev => upsertRequestInState(prev, request));
-          })
-          .catch((error) => {
-            console.error(`Failed to sync websocket ${event}:`, error);
-          });
-        return;
-      }
-
-      if (event === 'request:reorder' && payload?.id) {
-        data.getRequest(payload.id)
-          .then((request) => {
-            setCollections(prev => upsertRequestInState(prev, request));
-          })
-          .catch((error) => {
-            console.error('Failed to sync websocket request reorder:', error);
-          });
-        return;
-      }
-
-      if (event === 'example:create' && payload?.id) {
-        const syncExampleCreate = async () => {
-          try {
-            const example = payload.request_id ? payload : await data.getExample(payload.id);
-            const fullExample = example.request_data ? example : await data.getExample(example.id);
-
-            setCollections(prev => patchRequestInState(prev, example.request_id, (request) => ({
-              ...request,
-              example_count: (request.example_count || 0) + 1,
-            })));
-
-            if (selectedRequest?.id === fullExample.request_id) {
-              setExamples(prev => upsertExampleInList(prev, fullExample));
-            }
-          } catch (error) {
-            console.error('Failed to sync websocket example create:', error);
-          }
-        };
-
-        syncExampleCreate();
-        return;
-      }
-
-      if (event === 'example:update' && payload?.id) {
-        const syncExampleUpdate = async () => {
-          try {
-            const example = await data.getExample(payload.id);
-
-            setCollections(prev => patchRequestInState(prev, example.request_id, (request) => ({
-              ...request,
-            })));
-
-            if (selectedRequest?.id === example.request_id) {
-              setExamples(prev => upsertExampleInList(prev, example));
-            }
-          } catch (error) {
-            console.error('Failed to sync websocket example update:', error);
-          }
-        };
-
-        syncExampleUpdate();
-        return;
-      }
-
-      if (event === 'example:delete' && payload?.id) {
-        const deletedExampleRequestId =
-          payload.request_id
-          || examples.find((example) => example.id === payload.id)?.request_id
-          || openTabs.find((tab) => tab.id === `example-${payload.id}`)?.parentRequestId
-          || null;
-
-        if (deletedExampleRequestId) {
-          setCollections(prev => patchRequestInState(prev, deletedExampleRequestId, (request) => ({
-            ...request,
-            example_count: Math.max(0, (request.example_count || 0) - 1),
-          })));
-        }
-
-        setExamples(prev => prev.filter((example) => example.id !== payload.id));
-
-        return;
-      }
-
-      if (event === 'sync:import') {
-        loadCollections();
-      }
-
-      if (
-        event === 'example:create' ||
-        event === 'example:update' ||
-        event === 'example:delete'
-      ) {
-        if (selectedRequest?.id) {
-          data.getExamples(selectedRequest.id).then(setExamples);
-        }
-      }
-
-      if (
-        event === 'environment:create' ||
-        event === 'environment:update' ||
-        event === 'environment:delete' ||
-        event === 'environment:activate' ||
-        event === 'environment:deactivate'
-      ) {
-        // Environments are now workspace-scoped
-        if (activeWorkspace?.id) {
-          loadEnvironments(activeWorkspace.id);
-        }
-      }
-
-      // Workflow realtime events
-      if (event?.startsWith('workflow:')) {
-        loadWorkflows();
-        if (event === 'workflow:DELETE' && payload?.id) {
-          const tabId = `workflow-${payload.id}`;
-          const openTab = openTabs.find(t => t.id === tabId);
-          if (openTab) setDeletedTabs(prev => new Set([...prev, tabId]));
-        }
-      }
-    },
-    [activeWorkspace?.id, examples, loadCollections, loadEnvironments, loadWorkflows, openTabs, selectedRequest?.id, setCollections, setExamples, wasRecentlyModified]
-  );
-
-  useWebSocket(handleWebSocketMessage);
+  const { connected, reconnecting } = useRealtimeSync();
 
   // Hide the initial HTML loader once auth is checked
   useEffect(() => {
@@ -876,9 +285,10 @@ function AppContent() {
       activeEnvironment={activeEnvironment}
       collectionVariables={collectionVariables}
       rootCollectionId={rootCollectionId}
-      onEnvironmentUpdate={() => { activeWorkspace?.id && loadEnvironments(activeWorkspace.id); reloadCollectionVariables(); }}
+      onEnvironmentUpdate={onEnvironmentUpdate}
     >
     <div className="app">
+      <ConnectionStatus connected={connected} reconnecting={reconnecting} />
       {updateAvailable && (
         <div className="version-toast">
           {isTauri && tauriUpdate ? (
@@ -1098,7 +508,7 @@ function AppContent() {
               activeEnvironment={activeEnvironment}
               collectionVariables={collectionVariables}
               rootCollectionId={rootCollectionId}
-              onEnvironmentUpdate={() => { activeWorkspace?.id && loadEnvironments(activeWorkspace.id); reloadCollectionVariables(); }}
+              onEnvironmentUpdate={onEnvironmentUpdate}
             />
           ) : (
             <>
@@ -1121,7 +531,7 @@ function AppContent() {
                 activeEnvironment={activeEnvironment}
                 collectionVariables={collectionVariables}
                 rootCollectionId={rootCollectionId}
-                onEnvironmentUpdate={() => { activeWorkspace?.id && loadEnvironments(activeWorkspace.id); reloadCollectionVariables(); }}
+                onEnvironmentUpdate={onEnvironmentUpdate}
                 height={requestEditorHeight}
                 activeDetailTab={activeTab?.activeDetailTab || 'params'}
                 onActiveDetailTabChange={updateActiveDetailTab}
@@ -1146,73 +556,12 @@ function AppContent() {
         </main>
 
         {showCurlPanel && (
-          <>
-            <div
-              className="curl-resize-handle"
-              onMouseDown={startResizingCurl}
-            />
-            <aside className="curl-panel" style={{ width: curlPanelWidth }}>
-              <div className="curl-panel-header">
-                <span className="curl-panel-title">cURL</span>
-                <div className="curl-panel-actions">
-                <button
-                  className="btn-icon small"
-                  onClick={async () => {
-                    try {
-                      await navigator.clipboard.writeText(curlPreview);
-                      toast.success('cURL copied to clipboard');
-                    } catch {
-                      const textArea = document.createElement('textarea');
-                      textArea.value = curlPreview;
-                      textArea.style.position = 'fixed';
-                      textArea.style.left = '-9999px';
-                      document.body.appendChild(textArea);
-                      textArea.select();
-                      document.execCommand('copy');
-                      document.body.removeChild(textArea);
-                      toast.success('cURL copied to clipboard');
-                    }
-                  }}
-                  title="Copy to clipboard"
-                >
-                  <Copy size={14} />
-                </button>
-                <button
-                  className="btn-icon small"
-                  onClick={toggleCurlPanel}
-                  title="Close panel"
-                >
-                  <X size={14} />
-                </button>
-                </div>
-              </div>
-              <div className="curl-panel-code">
-                <CodeMirror
-                  value={curlPreview}
-                  readOnly
-                  editable={false}
-                  theme={theme === 'dark' ? 'dark' : 'light'}
-                  extensions={[
-                    shellLang,
-                    curlEditorTheme,
-                    theme === 'dark' ? curlDarkSyntax : curlLightSyntax,
-                    EditorView.lineWrapping,
-                  ]}
-                  basicSetup={{
-                    lineNumbers: true,
-                    highlightActiveLineGutter: false,
-                    highlightActiveLine: false,
-                    foldGutter: false,
-                    bracketMatching: false,
-                    closeBrackets: false,
-                    autocompletion: false,
-                    indentOnInput: false,
-                    searchKeymap: false,
-                  }}
-                />
-              </div>
-            </aside>
-          </>
+          <CurlPanel
+            width={curlPanelWidth}
+            theme={theme}
+            onResize={startResizingCurl}
+            onClose={toggleCurlPanel}
+          />
         )}
 
       </div>

--- a/src/components/ConnectionStatus.jsx
+++ b/src/components/ConnectionStatus.jsx
@@ -1,0 +1,56 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function ConnectionStatus({ connected, reconnecting }) {
+  const [showConnected, setShowConnected] = useState(false);
+  const [showLost, setShowLost] = useState(false);
+  const hasConnectedRef = useRef(false);
+
+  useEffect(() => {
+    if (connected && !hasConnectedRef.current) {
+      hasConnectedRef.current = true;
+      return;
+    }
+
+    if (connected && hasConnectedRef.current) {
+      setShowConnected(true);
+      setShowLost(false);
+      const timer = setTimeout(() => setShowConnected(false), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [connected]);
+
+  // Show "Connection lost" only after 5 seconds of being disconnected
+  useEffect(() => {
+    if (!connected && !reconnecting && hasConnectedRef.current) {
+      const timer = setTimeout(() => setShowLost(true), 5000);
+      return () => clearTimeout(timer);
+    }
+    setShowLost(false);
+  }, [connected, reconnecting]);
+
+  if (connected && showConnected) {
+    return (
+      <div className="connection-status connection-status--connected" data-testid="connection-status">
+        Connected
+      </div>
+    );
+  }
+
+  if (reconnecting) {
+    return (
+      <div className="connection-status connection-status--reconnecting" data-testid="connection-status">
+        Reconnecting...
+      </div>
+    );
+  }
+
+  if (showLost) {
+    return (
+      <div className="connection-status connection-status--lost" data-testid="connection-status">
+        Connection lost
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/CurlPanel.jsx
+++ b/src/components/CurlPanel.jsx
@@ -1,0 +1,160 @@
+import { useMemo } from 'react';
+import { Copy, X } from 'lucide-react';
+import CodeMirror from '@uiw/react-codemirror';
+import { StreamLanguage } from '@codemirror/language';
+import { shell } from '@codemirror/legacy-modes/mode/shell';
+import { EditorView } from '@codemirror/view';
+import { generateCurl } from './RequestEditor';
+import { useWorkbench } from '../contexts/WorkbenchContext';
+import { useToast } from './Toast';
+
+const curlEditorTheme = EditorView.theme({
+  '&': {
+    backgroundColor: 'transparent',
+    color: 'var(--text-primary)',
+    fontSize: '12px',
+    fontFamily: 'var(--font-mono)',
+    height: '100%',
+  },
+  '.cm-content': {
+    padding: '14px 4px',
+    caretColor: 'transparent',
+  },
+  '.cm-cursor': { display: 'none' },
+  '.cm-activeLine': { backgroundColor: 'transparent' },
+  '&.cm-focused .cm-activeLine': { backgroundColor: 'transparent' },
+  '.cm-gutters': {
+    backgroundColor: 'transparent',
+    color: 'var(--text-tertiary)',
+    border: 'none',
+    borderRight: '1px solid var(--border-subtle)',
+  },
+  '.cm-activeLineGutter': { backgroundColor: 'transparent' },
+  '&.cm-focused .cm-activeLineGutter': { backgroundColor: 'transparent' },
+  '.cm-lineNumbers .cm-gutterElement': {
+    padding: '0 8px 0 12px',
+    minWidth: '28px',
+    fontSize: '11px',
+  },
+  '.cm-scroller': {
+    fontFamily: 'var(--font-mono)',
+    lineHeight: '1.7',
+    overflow: 'auto',
+  },
+  '&.cm-focused': { outline: 'none' },
+  '.cm-selectionBackground': { backgroundColor: 'rgba(59, 130, 246, 0.2) !important' },
+  '&.cm-focused .cm-selectionBackground': { backgroundColor: 'rgba(59, 130, 246, 0.3) !important' },
+});
+
+const curlLightSyntax = EditorView.theme({
+  '.ͼd': { color: '#16a34a' },
+  '.ͼc': { color: '#d97706' },
+  '.ͼb': { color: '#0284c7' },
+  '.ͼe': { color: '#7c3aed' },
+});
+
+const curlDarkSyntax = EditorView.theme({
+  '.ͼd': { color: '#4ade80' },
+  '.ͼc': { color: '#fbbf24' },
+  '.ͼb': { color: '#38bdf8' },
+  '.ͼe': { color: '#a78bfa' },
+});
+
+const shellLang = StreamLanguage.define(shell);
+
+export function CurlPanel({ width, theme, onResize, onClose }) {
+  const toast = useToast();
+  const { activeTab, selectedRequest, selectedExample, activeEnvironment } = useWorkbench();
+
+  const curlPreview = useMemo(() => {
+    const req = activeTab?.type === 'example'
+      ? selectedExample?.request_data
+      : selectedRequest;
+    if (!req) return '';
+    const sub = (text) => {
+      if (!text || !activeEnvironment) return text;
+      let result = text;
+      for (const v of activeEnvironment.variables) {
+        if (v.enabled && v.key) {
+          result = result.replace(new RegExp(`\\{\\{${v.key}\\}\\}`, 'g'), v.value || '');
+        }
+      }
+      return result;
+    };
+    const headers = (req.headers || []).map(h => ({ ...h, key: sub(h.key), value: sub(h.value) }));
+    const fd = (req.form_data || []).map(f => ({ ...f, key: sub(f.key), value: f.type === 'file' ? f.value : sub(f.value) }));
+    return generateCurl(
+      req.method || 'GET',
+      sub(req.url || ''),
+      headers,
+      sub(req.body || ''),
+      req.body_type || 'none',
+      fd,
+      req.auth_type || 'none',
+      sub(req.auth_token || '')
+    );
+  }, [selectedRequest, selectedExample, activeTab?.type, activeEnvironment]);
+
+  return (
+    <>
+      <div className="curl-resize-handle" onMouseDown={onResize} />
+      <aside className="curl-panel" style={{ width }}>
+        <div className="curl-panel-header">
+          <span className="curl-panel-title">cURL</span>
+          <div className="curl-panel-actions">
+            <button
+              className="btn-icon small"
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(curlPreview);
+                  toast.success('cURL copied to clipboard');
+                } catch {
+                  const textArea = document.createElement('textarea');
+                  textArea.value = curlPreview;
+                  textArea.style.position = 'fixed';
+                  textArea.style.left = '-9999px';
+                  document.body.appendChild(textArea);
+                  textArea.select();
+                  document.execCommand('copy');
+                  document.body.removeChild(textArea);
+                  toast.success('cURL copied to clipboard');
+                }
+              }}
+              title="Copy to clipboard"
+            >
+              <Copy size={14} />
+            </button>
+            <button className="btn-icon small" onClick={onClose} title="Close panel">
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+        <div className="curl-panel-code">
+          <CodeMirror
+            value={curlPreview}
+            readOnly
+            editable={false}
+            theme={theme === 'dark' ? 'dark' : 'light'}
+            extensions={[
+              shellLang,
+              curlEditorTheme,
+              theme === 'dark' ? curlDarkSyntax : curlLightSyntax,
+              EditorView.lineWrapping,
+            ]}
+            basicSetup={{
+              lineNumbers: true,
+              highlightActiveLineGutter: false,
+              highlightActiveLine: false,
+              foldGutter: false,
+              bracketMatching: false,
+              closeBrackets: false,
+              autocompletion: false,
+              indentOnInput: false,
+              searchKeymap: false,
+            }}
+          />
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,40 @@
+import { Component } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+export class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-boundary-fallback" data-testid="error-boundary-fallback">
+          <div className="error-boundary-card">
+            <AlertTriangle size={48} className="error-boundary-icon" />
+            <h1 className="error-boundary-heading">Something went wrong</h1>
+            <p className="error-boundary-message">{this.state.error?.message || 'An unexpected error occurred'}</p>
+            <button
+              className="error-boundary-reload"
+              data-testid="error-boundary-reload"
+              onClick={() => window.location.reload()}
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/JsonEditor.jsx
+++ b/src/components/JsonEditor.jsx
@@ -2,233 +2,13 @@ import { useCallback, useMemo, useState, useEffect } from 'react';
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import { EditorView } from '@codemirror/view';
-import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
-import { linter, lintGutter } from '@codemirror/lint';
-import { tags } from '@lezer/highlight';
+import { lintGutter } from '@codemirror/lint';
 import JSON5 from 'json5';
-import jsonlint from 'jsonlint-mod';
 import { createEnvVariableExtensions } from '../utils/envVariableExtension';
+import { createJsonLinter } from '../utils/jsonLinter';
+import { extractComments, reinsertComments } from '../utils/jsonComments';
+import { baseTheme, lightSyntaxHighlight, lightSelection, darkSyntaxHighlight, darkSelection } from '../utils/jsonEditorTheme';
 import { useVariablePopover } from './VariablePopover';
-
-function createJsonLinter() {
-  return linter((view) => {
-    const doc = view.state.doc;
-    const text = doc.toString();
-    if (!text.trim()) return [];
-
-    const envVarRegex = /"?\{\{([^}]+)\}\}"?/g;
-    let safeText = text.replace(envVarRegex, (match) => {
-      const len = match.length;
-      if (len < 2) return match;
-      return '"' + 'a'.repeat(len - 2) + '"';
-    });
-
-    // Strip comments (JSON5 supports them, but jsonlint doesn't)
-    // Match strings first to skip them, then replace comments with spaces to preserve positions
-    safeText = safeText.replace(/"(?:[^"\\]|\\.)*"|\/\/.*$|\/\*[\s\S]*?\*\//gm, (match) => {
-      if (match.startsWith('"')) return match;
-      return match.replace(/[^\n]/g, ' ');
-    });
-
-    try {
-      jsonlint.parse(safeText);
-      return [];
-    } catch (e) {
-      const errMsg = e.message || '';
-      const lines = errMsg.split('\n');
-
-      // Extract line number: "Parse error on line N:"
-      const lineMatch = errMsg.match(/line (\d+)/);
-      // Extract "Expecting ..., got ..." message
-      const expectingLine = lines.find(l => /^Expecting\s/.test(l));
-      // Extract column from caret pointer line
-      const ptrLine = lines.find(l => l.includes('^'));
-      const errorCol = ptrLine ? ptrLine.indexOf('^') : 0;
-
-      let message = errMsg.split('\n')[0];
-      if (expectingLine) {
-        const gotMatch = expectingLine.match(/got\s+'([^']+)'/);
-        const got = gotMatch ? gotMatch[1] : '';
-        const tokenNames = { STRING: 'string', NUMBER: 'number', NULL: 'null', TRUE: 'true', FALSE: 'false', EOF: 'end of input', undefined: 'unexpected token' };
-        const gotLabel = tokenNames[got] || `'${got}'`;
-        const expected = [];
-        const tokenRegex = /'([^']*)'/g;
-        const expectPart = expectingLine.replace(/,\s*got\s+.*$/, '');
-        let m;
-        while ((m = tokenRegex.exec(expectPart)) !== null) {
-          if (m[1] !== 'EOF') expected.push(m[1]);
-        }
-        const isValue = (t) => ['STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['].includes(t);
-        const has = (t) => expected.includes(t);
-
-        if (has(',') && has(':')) message = got === 'STRING' ? 'Expected comma' : "Expected ':' after property name";
-        else if (has(',')) message = 'Expected comma';
-        else if (has(':')) message = "Expected ':' after property name";
-        else if (has('STRING') && has('}') && !has('NUMBER')) message = got === ',' ? 'Unexpected comma' : `Expected property name or '}'`;
-        else if (expected.some(isValue) && (got === '}' || got === ']')) message = 'Trailing comma is not allowed';
-        else if (expected.some(isValue)) message = `Expected a value, got ${gotLabel}`;
-        else message = `Unexpected ${gotLabel}`;
-      }
-
-      if (!lineMatch) return [];
-      const errorLine = parseInt(lineMatch[1], 10);
-
-      if (errorLine < 1 || errorLine > doc.lines) {
-        const lastLine = doc.line(doc.lines);
-        const trimmed = lastLine.text.trimEnd();
-        const from = lastLine.from + Math.max(0, trimmed.length - 1);
-        const to = lastLine.from + Math.max(trimmed.length, 1);
-        return [{ from, to: Math.min(to, doc.length), severity: 'error', message }];
-      }
-
-      const line = doc.line(errorLine);
-      const from = line.from + Math.min(errorCol, line.length);
-
-      let to = line.from + line.text.trimEnd().length;
-      if (to <= from) to = Math.min(from + 1, line.to);
-      to = Math.min(to, doc.length);
-
-      return [{ from, to, severity: 'error', message }];
-    }
-  }, { delay: 300 });
-}
-
-// Custom theme that matches the app's design system using CSS variables
-const baseTheme = EditorView.theme({
-  '&': {
-    backgroundColor: 'var(--bg-input)',
-    color: 'var(--text-primary)',
-    fontSize: '13px',
-    fontFamily: 'var(--font-mono)',
-  },
-  '.cm-content': {
-    caretColor: 'var(--accent-primary)',
-    padding: '12px 4px',
-  },
-  '.cm-cursor': {
-    borderLeftColor: 'var(--accent-primary)',
-  },
-  '.cm-selectionMatch': {
-    backgroundColor: 'rgba(59, 130, 246, 0.2)',
-  },
-  '.cm-activeLine': {
-    backgroundColor: 'transparent',
-  },
-  '&.cm-focused .cm-activeLine': {
-    backgroundColor: 'rgba(128, 128, 128, 0.08)',
-  },
-  '.cm-gutters': {
-    backgroundColor: 'var(--bg-input)',
-    color: 'var(--text-tertiary)',
-    border: 'none',
-    borderRight: '1px solid var(--border-subtle)',
-  },
-  '.cm-activeLineGutter': {
-    backgroundColor: 'transparent',
-  },
-  '&.cm-focused .cm-activeLineGutter': {
-    backgroundColor: 'rgba(128, 128, 128, 0.08)',
-  },
-  '.cm-lineNumbers .cm-gutterElement': {
-    padding: '0 8px 0 12px',
-    minWidth: '32px',
-  },
-  '.cm-scroller': {
-    fontFamily: 'var(--font-mono)',
-    lineHeight: '1.6',
-  },
-  '.cm-foldPlaceholder': {
-    backgroundColor: 'var(--bg-tertiary)',
-    border: '1px solid var(--border-primary)',
-    color: 'var(--text-tertiary)',
-  },
-  '.cm-matchingBracket': {
-    backgroundColor: 'var(--accent-primary-subtle)',
-    outline: '1px solid var(--accent-primary)',
-  },
-  // Placeholder styling
-  '.cm-placeholder': {
-    color: 'var(--text-tertiary)',
-    fontStyle: 'italic',
-  },
-  // Lint error squiggly underline
-  '.cm-lintRange-error': {
-    backgroundImage: 'none',
-    textDecoration: 'underline wavy var(--accent-danger)',
-    textDecorationSkipInk: 'none',
-    textUnderlineOffset: '2px',
-  },
-  // Lint tooltip
-  '.cm-tooltip.cm-tooltip-lint': {
-    backgroundColor: 'var(--bg-elevated)',
-    border: '1px solid var(--border-primary)',
-    borderRadius: 'var(--radius-sm)',
-    boxShadow: 'var(--shadow-lg)',
-    fontFamily: 'var(--font-sans)',
-    fontSize: '12px',
-    padding: '0',
-  },
-  '.cm-diagnostic-error': {
-    color: 'var(--accent-danger)',
-    borderLeft: '3px solid var(--accent-danger)',
-    padding: '6px 10px',
-    margin: '0',
-  },
-  // Lint gutter
-  '.cm-gutter-lint': {
-    width: '14px',
-  },
-  '.cm-gutter-lint .cm-gutterElement': {
-    padding: '0',
-  },
-});
-
-// Light theme syntax colors
-const lightSyntaxHighlight = syntaxHighlighting(HighlightStyle.define([
-  { tag: tags.string, color: '#16a34a' },
-  { tag: tags.number, color: '#d97706' },
-  { tag: tags.bool, color: '#7c3aed' },
-  { tag: tags.null, color: '#dc2626' },
-  { tag: tags.propertyName, color: '#0284c7' },
-  { tag: tags.punctuation, color: '#64748b' },
-  { tag: tags.brace, color: '#64748b' },
-  { tag: tags.squareBracket, color: '#64748b' },
-]));
-
-const lightSelection = EditorView.theme({
-  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
-    backgroundColor: 'rgba(37, 99, 235, 0.4) !important',
-  },
-  '.cm-line ::selection': {
-    backgroundColor: 'rgba(37, 99, 235, 0.45) !important',
-    color: '#1e293b !important',
-  },
-  '.cm-content': {
-    caretColor: 'var(--accent-primary)',
-  },
-});
-
-// Dark theme syntax colors
-const darkSyntaxHighlight = syntaxHighlighting(HighlightStyle.define([
-  { tag: tags.string, color: '#4ade80' },
-  { tag: tags.number, color: '#fbbf24' },
-  { tag: tags.bool, color: '#a78bfa' },
-  { tag: tags.null, color: '#f87171' },
-  { tag: tags.propertyName, color: '#38bdf8' },
-  { tag: tags.punctuation, color: '#94a3b8' },
-  { tag: tags.brace, color: '#94a3b8' },
-  { tag: tags.squareBracket, color: '#94a3b8' },
-]));
-
-const darkSelection = EditorView.theme({
-  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
-    backgroundColor: 'rgba(96, 165, 250, 0.45) !important',
-  },
-  '.cm-line ::selection': {
-    backgroundColor: 'rgba(96, 165, 250, 0.5) !important',
-    color: '#f1f5f9 !important',
-  },
-});
 
 export function JsonEditor({
   value,
@@ -292,54 +72,6 @@ export function JsonEditor({
     onChange?.(val);
   }, [onChange]);
 
-  // Extract comments and return stripped text + comment associations
-  const extractComments = useCallback((text) => {
-    const comments = [];
-    const stripped = text.replace(/"(?:[^"\\]|\\.)*"|\/\/.*$|\/\*[\s\S]*?\*\//gm, (match, offset) => {
-      if (match.startsWith('"')) return match;
-      if (match.startsWith('//')) {
-        const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
-        const before = text.substring(lineStart, offset);
-        // Find the JSON key this comment is associated with (nearest "key": on the same line)
-        const keyMatch = before.match(/"([^"]+)"\s*:/);
-        if (keyMatch) comments.push({ key: keyMatch[1], text: match.trim() });
-        return ' '.repeat(match.length);
-      }
-      return ' '.repeat(match.length);
-    });
-    return { stripped, comments };
-  }, []);
-
-  // Reinsert comments by matching key names in formatted output
-  const reinsertComments = useCallback((formatted, comments) => {
-    if (comments.length === 0) return formatted;
-    const lines = formatted.split('\n');
-    for (const { key, text } of comments) {
-      const keyPattern = `"${key}"`;
-      const idx = lines.findIndex(l => l.includes(keyPattern));
-      if (idx === -1) continue;
-      // Check if value opens an array/object on this line
-      const afterKey = lines[idx].substring(lines[idx].indexOf(keyPattern) + keyPattern.length);
-      const opensBlock = /:\s*[\[{]\s*$/.test(afterKey);
-      if (opensBlock) {
-        // Find the matching closing bracket/brace
-        const opener = afterKey.trim().slice(-1);
-        const closer = opener === '[' ? ']' : '}';
-        let depth = 1;
-        for (let i = idx + 1; i < lines.length && depth > 0; i++) {
-          for (const ch of lines[i]) {
-            if (ch === opener) depth++;
-            else if (ch === closer) depth--;
-            if (depth === 0) { lines[i] = lines[i] + ' ' + text; break; }
-          }
-        }
-      } else {
-        lines[idx] = lines[idx] + ' ' + text;
-      }
-    }
-    return lines.join('\n');
-  }, []);
-
   const handleBeautify = useCallback(() => {
     if (!value) return;
     try {
@@ -361,7 +93,7 @@ export function JsonEditor({
     } catch (e) {
       console.warn('Cannot beautify invalid JSON:', e.message);
     }
-  }, [value, onChange, extractComments, reinsertComments]);
+  }, [value, onChange]);
 
   const handleMinify = useCallback(() => {
     if (!value) return;
@@ -384,7 +116,7 @@ export function JsonEditor({
     } catch (e) {
       console.warn('Cannot minify invalid JSON:', e.message);
     }
-  }, [value, onChange, extractComments]);
+  }, [value, onChange]);
 
   // Check if JSON is valid for showing beautify button state
   // Uses JSON5 to allow comments and trailing commas

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -5,7 +5,8 @@ import { useConfirm } from '../ConfirmModal';
 import { useToast } from '../Toast';
 import { useLocalStorageSet } from '../../hooks/useLocalStorage';
 import { useInlineRename } from '../../hooks/useInlineRename';
-import { useDragPreview } from '../../hooks/useDragPreview';
+import { useSidebarDragDrop } from '../../hooks/useSidebarDragDrop';
+import useCollectionStore from '../../stores/collectionStore';
 import { METHOD_COLORS } from '../../constants/methodColors';
 import { RequestItem } from './RequestItem';
 
@@ -53,24 +54,17 @@ export function Sidebar({
 }) {
   const confirm = useConfirm();
   const toast = useToast();
+  const setCollections = useCollectionStore((s) => s.setCollections);
   const [expandedCollections, setExpandedCollections] = useLocalStorageSet('expandedCollections');
   const [expandedRequests, setExpandedRequests] = useLocalStorageSet('expandedRequests');
   const [requestExamples, setRequestExamples] = useState({});
   const [loadingExamples, setLoadingExamples] = useState({});
   const { editingId, editingName, setEditingName, startEditing, finishEditing } = useInlineRename();
-  const setDragPreview = useDragPreview();
   const [showWorkflowsOnly, setShowWorkflowsOnly] = useState(false);
   const [menuOpen, setMenuOpen] = useState(null);
   const [collectionMenuOpen, setCollectionMenuOpen] = useState(null);
-  const [draggedRequest, setDraggedRequest] = useState(null);
-  const [dragOverRequest, setDragOverRequest] = useState(null);
-  const [draggedFolder, setDraggedFolder] = useState(null);
-  const [dragOverFolder, setDragOverFolder] = useState(null);
-  const [draggedExample, setDraggedExample] = useState(null);
-  const [dragOverExample, setDragOverExample] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [exampleMenuOpen, setExampleMenuOpen] = useState(null);
-  const [dragOverCollection, setDragOverCollection] = useState(null);
   const menuRef = useRef(null);
   const collectionMenuRef = useRef(null);
   const exampleMenuRef = useRef(null);
@@ -222,6 +216,17 @@ export function Sidebar({
         return (a.created_at || 0) - (b.created_at || 0);
       });
   };
+
+  const {
+    draggedRequest, dragOverRequest, draggedFolder, dragOverFolder,
+    draggedExample, dragOverExample, dragOverCollection, folderDropZone,
+    handleDragStart, handleDragEnd, handleDragOver, handleDragLeave, handleDrop,
+    handleCollectionDragOver, handleCollectionDragLeave, handleCollectionDrop,
+    handleFolderDragStart, handleFolderDragEnd,
+    handleExampleDragStart, handleExampleDragEnd, handleExampleDragOver,
+    handleExampleDragLeave, handleExampleDrop,
+    isSameRootCollection,
+  } = useSidebarDragDrop(collections, getChildCollections, setCollections);
 
   // Filter requests based on search query
   const filterRequests = (requests) => {
@@ -498,294 +503,6 @@ export function Sidebar({
       }
     }
     finishEditing();
-  };
-
-  // Drag and drop handlers
-  const handleDragStart = (e, request, collectionId) => {
-    setDraggedRequest({ ...request, collectionId });
-    e.dataTransfer.effectAllowed = 'copyMove';
-    e.dataTransfer.setData('text/plain', request.id);
-    e.dataTransfer.setData('text/x-request-id', request.id);
-    setDragPreview(e, `${request.method} ${request.name}`, METHOD_COLORS[request.method]);
-  };
-
-  const handleDragEnd = () => {
-    setDraggedRequest(null);
-    setDragOverRequest(null);
-  };
-
-  const handleDragOver = (e, request, collectionId) => {
-    if (!draggedRequest || draggedRequest.id === request.id) return;
-    if (!isSameRootCollection(draggedRequest.collectionId, collectionId)) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    if (draggedRequest.id !== request.id) {
-      setDragOverRequest(request.id);
-    }
-  };
-
-  const handleDragLeave = () => {
-    setDragOverRequest(null);
-  };
-
-  const handleDrop = async (e, targetRequest, collectionId, requests) => {
-    e.preventDefault();
-    setDragOverRequest(null);
-    setDragOverCollection(null);
-
-    if (!draggedRequest || draggedRequest.id === targetRequest.id) return;
-    if (!isSameRootCollection(draggedRequest.collectionId, collectionId)) return;
-
-    // Cross-folder move: move then reorder in the target
-    if (draggedRequest.collectionId !== collectionId) {
-      try {
-        await data.moveRequest(draggedRequest.id, collectionId);
-        const targetIds = requests.map(r => r.id);
-        const targetIndex = targetIds.indexOf(targetRequest.id);
-        targetIds.splice(targetIndex, 0, draggedRequest.id);
-        await data.reorderRequests(collectionId, targetIds);
-        toast.success('Request moved');
-      } catch (err) {
-        toast.error('Failed to move request');
-      }
-      setDraggedRequest(null);
-      return;
-    }
-
-    // Same-collection reorder
-    const requestIds = requests.map(r => r.id);
-    const draggedIndex = requestIds.indexOf(draggedRequest.id);
-    const targetIndex = requestIds.indexOf(targetRequest.id);
-
-    requestIds.splice(draggedIndex, 1);
-    requestIds.splice(targetIndex, 0, draggedRequest.id);
-
-    try {
-      await data.reorderRequests(collectionId, requestIds);
-      toast.success('Request reordered');
-    } catch (err) {
-      toast.error('Failed to reorder requests');
-    }
-
-    setDraggedRequest(null);
-  };
-
-  // Drop onto a collection/folder header
-  // folderDropZone: 'before' | 'inside' | 'after' — determined by mouse Y position
-  const [folderDropZone, setFolderDropZone] = useState(null);
-
-  const getFolderDropZone = (e) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const y = e.clientY - rect.top;
-    const ratio = y / rect.height;
-    if (ratio < 0.3) return 'before';
-    if (ratio > 0.7) return 'after';
-    return 'inside';
-  };
-
-  const handleCollectionDragOver = (e, collectionId) => {
-    if (!draggedRequest && !draggedFolder) return;
-    // Block cross-collection moves
-    const dragSourceId = draggedRequest?.collectionId || draggedFolder?.parent_id;
-    if (dragSourceId && !isSameRootCollection(dragSourceId, collectionId)) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-
-    if (draggedFolder && draggedFolder.id !== collectionId) {
-      const zone = getFolderDropZone(e);
-      setFolderDropZone(zone);
-      if (zone === 'inside') {
-        setDragOverCollection(collectionId);
-        setDragOverFolder(null);
-      } else {
-        // Edge: show reorder line (works for siblings and non-siblings)
-        setDragOverFolder(collectionId);
-        setDragOverCollection(null);
-      }
-    } else {
-      setDragOverCollection(collectionId);
-    }
-  };
-
-  const handleCollectionDragLeave = () => {
-    setDragOverCollection(null);
-    setDragOverFolder(null);
-    setFolderDropZone(null);
-  };
-
-  const handleCollectionDrop = async (e, collectionId, siblingCollections) => {
-    e.preventDefault();
-    const zone = folderDropZone;
-    setDragOverCollection(null);
-    setDragOverFolder(null);
-    setFolderDropZone(null);
-
-    // Folder drag: reorder (edges) or reparent (center)
-    if (draggedFolder) {
-      if (draggedFolder.id === collectionId) return;
-
-      const targetCollection = collections.find(c => c.id === collectionId);
-      const isSibling = draggedFolder.parent_id === targetCollection?.parent_id;
-      const targetParentId = targetCollection?.parent_id;
-
-      // Edge drop → place beside the target (as sibling of target)
-      if (zone !== 'inside') {
-        if (isDescendant(draggedFolder.id, collectionId)) return;
-
-        // If not already a sibling, move to target's parent first
-        if (!isSibling) {
-          if (draggedFolder.parent_id === targetParentId) { setDraggedFolder(null); return; }
-          try {
-            await data.moveCollection(draggedFolder.id, targetParentId);
-          } catch (err) {
-            toast.error('Failed to move folder');
-            setDraggedFolder(null);
-            return;
-          }
-        }
-
-        // Reorder among the target's siblings
-        const newSiblings = isSibling
-          ? siblingCollections
-          : getChildCollections(targetParentId);
-        const ids = newSiblings.map(c => c.id);
-
-        // Remove dragged from current position (if present)
-        const draggedIndex = ids.indexOf(draggedFolder.id);
-        if (draggedIndex !== -1) ids.splice(draggedIndex, 1);
-
-        // Insert at target position
-        let targetIndex = ids.indexOf(collectionId);
-        if (targetIndex === -1) { setDraggedFolder(null); return; }
-        if (zone === 'after') targetIndex += 1;
-        ids.splice(targetIndex, 0, draggedFolder.id);
-
-        try {
-          await data.reorderCollections(targetParentId, ids);
-          toast.success(isSibling ? 'Folder reordered' : 'Folder moved');
-        } catch (err) {
-          toast.error('Failed to reorder folders');
-        }
-        setDraggedFolder(null);
-        return;
-      }
-
-      // Center drop → reparent (move into target)
-      if (draggedFolder.parent_id === collectionId) return;
-      if (isDescendant(draggedFolder.id, collectionId)) return;
-      try {
-        await data.moveCollection(draggedFolder.id, collectionId);
-        toast.success('Folder moved');
-      } catch (err) {
-        toast.error('Failed to move folder');
-      }
-      setDraggedFolder(null);
-      return;
-    }
-
-    // Dropping a request into a folder
-    if (!draggedRequest || draggedRequest.collectionId === collectionId) return;
-
-    try {
-      await data.moveRequest(draggedRequest.id, collectionId);
-      toast.success('Request moved');
-    } catch (err) {
-      toast.error('Failed to move request');
-    }
-
-    setDraggedRequest(null);
-  };
-
-  // Find the root (top-level) collection for any collection ID
-  const getRootCollectionId = (collectionId) => {
-    let current = collections.find(c => c.id === collectionId);
-    while (current?.parent_id) {
-      current = collections.find(c => c.id === current.parent_id);
-    }
-    return current?.id;
-  };
-
-  // Check if two collection IDs belong to the same top-level collection
-  const isSameRootCollection = (idA, idB) => {
-    return getRootCollectionId(idA) === getRootCollectionId(idB);
-  };
-
-  // Check if targetId is a descendant of parentId (prevent circular moves)
-  const isDescendant = (parentId, targetId) => {
-    const check = (id) => {
-      const children = collections.filter(c => c.parent_id === id);
-      for (const child of children) {
-        if (child.id === targetId) return true;
-        if (check(child.id)) return true;
-      }
-      return false;
-    };
-    return check(parentId);
-  };
-
-  // Folder drag handlers (only for folders, not top-level collections)
-  const handleFolderDragStart = (e, collection) => {
-    setDraggedFolder(collection);
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', collection.id);
-    setDragPreview(e, `📁 ${collection.name}`);
-  };
-
-  const handleFolderDragEnd = () => {
-    setDraggedFolder(null);
-    setDragOverFolder(null);
-    setDragOverCollection(null);
-    setFolderDropZone(null);
-  };
-
-  // Example drag handlers
-  const handleExampleDragStart = (e, example, requestId) => {
-    setDraggedExample({ ...example, requestId });
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', example.id);
-    e.stopPropagation();
-    setDragPreview(e, `📄 ${example.name}`);
-  };
-
-  const handleExampleDragEnd = () => {
-    setDraggedExample(null);
-    setDragOverExample(null);
-  };
-
-  const handleExampleDragOver = (e, example) => {
-    if (!draggedExample || draggedExample.id === example.id) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    setDragOverExample(example.id);
-  };
-
-  const handleExampleDragLeave = () => {
-    setDragOverExample(null);
-  };
-
-  const handleExampleDrop = async (e, targetExample, requestId, examples) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDragOverExample(null);
-
-    if (!draggedExample || draggedExample.id === targetExample.id) return;
-    if (draggedExample.requestId !== requestId) return;
-
-    const ids = examples.map(ex => ex.id);
-    const draggedIndex = ids.indexOf(draggedExample.id);
-    const targetIndex = ids.indexOf(targetExample.id);
-    if (draggedIndex === -1 || targetIndex === -1) return;
-
-    ids.splice(draggedIndex, 1);
-    ids.splice(targetIndex, 0, draggedExample.id);
-
-    try {
-      await data.reorderExamples(requestId, ids);
-    } catch (err) {
-      console.error('Failed to reorder examples:', err);
-    }
-
-    setDraggedExample(null);
   };
 
   // Expand all folders

--- a/src/hooks/useClipboardLinks.js
+++ b/src/hooks/useClipboardLinks.js
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useWorkbench } from '../contexts/WorkbenchContext';
+import { useToast } from '../components/Toast';
+import * as data from '../data/index.js';
+
+export function useClipboardLinks() {
+  const toast = useToast();
+  const { user } = useAuth();
+  const {
+    collections,
+    openCollectionInTab,
+    openRequestInTab,
+    openExampleInTab,
+    setRevealCollectionId,
+    setRevealRequestId,
+  } = useWorkbench();
+  const lastClipboardLinkRef = useRef(null);
+
+  useEffect(() => {
+    if (!user) return;
+    const baseUrl = import.meta.env.VITE_APP_URL || window.location.origin;
+    const pattern = new RegExp(
+      `^${baseUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/\\?.*type=(collection|folder|request|example)&id=([0-9a-f-]+)`
+    );
+
+    const handleFocus = async () => {
+      let text;
+      try {
+        text = await navigator.clipboard.readText();
+      } catch {
+        return;
+      }
+      if (!text) return;
+      const match = text.match(pattern);
+      if (!match) return;
+      const type = match[1];
+      const id = match[2];
+
+      const urlParams = new URLSearchParams(text.split('?')[1]);
+      const uid = urlParams.get('uid');
+      if (uid && uid === String(user.id)) return;
+
+      if (text === lastClipboardLinkRef.current) return;
+      lastClipboardLinkRef.current = text;
+
+      if (type === 'collection' || type === 'folder') {
+        const found = collections.find(c => c.id === id);
+        if (!found) return;
+        toast.action(`Open shared ${type}?`, {
+          label: 'Open',
+          onClick: () => {
+            openCollectionInTab(found, { replacePreview: false });
+            setRevealCollectionId(id);
+          },
+        });
+      } else if (type === 'request') {
+        let request = null;
+        for (const c of collections) {
+          request = c.requests?.find(r => r.id === id);
+          if (request) break;
+        }
+        if (!request) return;
+        toast.action('Open shared request?', {
+          label: 'Open',
+          onClick: async () => {
+            const fullRequest = await data.getRequest(id);
+            openRequestInTab(fullRequest, { replacePreview: false });
+            setRevealRequestId(id);
+          },
+        });
+      } else if (type === 'example') {
+        toast.action('Open shared example?', {
+          label: 'Open',
+          onClick: async () => {
+            try {
+              const example = await data.getExample(id);
+              const parentRequest = await data.getRequest(example.request_id);
+              openExampleInTab(example, parentRequest, { replacePreview: false });
+              setRevealRequestId(parentRequest.id);
+            } catch {
+              toast.error('Failed to open shared example.');
+            }
+          },
+        });
+      }
+    };
+
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, [user, collections, toast, openCollectionInTab, openRequestInTab, openExampleInTab, setRevealCollectionId, setRevealRequestId]);
+}

--- a/src/hooks/useCollectionVariables.js
+++ b/src/hooks/useCollectionVariables.js
@@ -1,0 +1,47 @@
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useWorkbench } from '../contexts/WorkbenchContext';
+import { useWorkspace } from '../contexts/WorkspaceContext';
+import * as data from '../data/index.js';
+
+export function useCollectionVariables() {
+  const { activeTab, selectedRequest, collections, loadEnvironments } = useWorkbench();
+  const { activeWorkspace } = useWorkspace();
+  const [collectionVariables, setCollectionVariables] = useState([]);
+
+  const activeCollectionId = useMemo(() => {
+    if (activeTab?.type === 'collection') return activeTab.collection?.id;
+    if (selectedRequest?.collection_id) return selectedRequest.collection_id;
+    return null;
+  }, [activeTab?.type, activeTab?.collection?.id, selectedRequest?.collection_id]);
+
+  const rootCollectionId = useMemo(() => {
+    if (!activeCollectionId || !collections) return null;
+    let currentId = activeCollectionId;
+    let iterations = 0;
+    while (currentId && iterations < 50) {
+      const col = collections.find(c => c.id === currentId);
+      if (!col) break;
+      if (!col.parent_id) return col.id;
+      currentId = col.parent_id;
+      iterations++;
+    }
+    return currentId;
+  }, [activeCollectionId, collections]);
+
+  const reloadCollectionVariables = useCallback(() => {
+    if (!rootCollectionId) return;
+    data.getCollectionVariables(rootCollectionId).then(setCollectionVariables).catch(() => setCollectionVariables([]));
+  }, [rootCollectionId]);
+
+  useEffect(() => {
+    if (!rootCollectionId) { setCollectionVariables([]); return; }
+    reloadCollectionVariables();
+  }, [rootCollectionId, reloadCollectionVariables]);
+
+  const onEnvironmentUpdate = useCallback(() => {
+    if (activeWorkspace?.id) loadEnvironments(activeWorkspace.id);
+    reloadCollectionVariables();
+  }, [activeWorkspace?.id, loadEnvironments, reloadCollectionVariables]);
+
+  return { collectionVariables, rootCollectionId, reloadCollectionVariables, onEnvironmentUpdate };
+}

--- a/src/hooks/useRealtimeSync.js
+++ b/src/hooks/useRealtimeSync.js
@@ -1,0 +1,236 @@
+import { useCallback } from 'react';
+import { isEqual, pick } from 'lodash-es';
+import { useWebSocket } from './useWebSocket';
+import { useWorkbench } from '../contexts/WorkbenchContext';
+import { useWorkspace } from '../contexts/WorkspaceContext';
+import {
+  upsertCollectionInState,
+  removeCollectionBranch,
+  upsertRequestInState,
+  removeRequestFromState,
+  patchRequestInState,
+  upsertExampleInList,
+} from '../utils/collectionState';
+import * as data from '../data/index.js';
+
+export function useRealtimeSync() {
+  const {
+    openTabs,
+    setCollections,
+    setExamples,
+    setConflictedTabs,
+    setDeletedTabs,
+    loadCollections,
+    loadEnvironments,
+    loadWorkflows,
+    selectedRequest,
+    examples,
+    wasRecentlyModified,
+  } = useWorkbench();
+
+  const { activeWorkspace } = useWorkspace();
+
+  const handleWebSocketMessage = useCallback(
+    (message) => {
+      const { event, data: payload } = message;
+      if (event === 'request:update' && payload?.id) {
+        const tabId = `request-${payload.id}`;
+        if (wasRecentlyModified(tabId)) return;
+
+        const openTab = openTabs.find(t => t.id === tabId);
+        if (openTab) {
+          const parseJson = (v) => typeof v === 'string' ? JSON.parse(v || '[]') : (v || []);
+          const normalized = { ...payload, headers: parseJson(payload.headers), params: parseJson(payload.params), form_data: parseJson(payload.form_data) };
+          const requestContentFields = ['name', 'method', 'url', 'body', 'body_type', 'auth_type', 'auth_token', 'pre_script', 'post_script', 'headers', 'params', 'form_data'];
+          const contentChanged = openTab.request && !isEqual(pick(normalized, requestContentFields), pick(openTab.request, requestContentFields));
+
+          if (contentChanged) {
+            setConflictedTabs(prev => ({ ...prev, [tabId]: payload }));
+          }
+        }
+      }
+
+      if (event === 'request:create' && payload?.id) {
+        if (wasRecentlyModified(`request-${payload.id}`)) return;
+      }
+
+      if (event === 'example:update' && payload?.id) {
+        const tabId = `example-${payload.id}`;
+        if (wasRecentlyModified(tabId)) return;
+
+        const openTab = openTabs.find(t => t.id === tabId);
+        if (openTab) {
+          const exampleContentFields = ['name', 'request_data', 'response_data'];
+          const contentChanged = openTab.example && !isEqual(pick(payload, exampleContentFields), pick(openTab.example, exampleContentFields));
+
+          if (contentChanged) {
+            setConflictedTabs(prev => ({ ...prev, [tabId]: payload }));
+          }
+        }
+      }
+
+      if (event === 'example:create' && payload?.id) {
+        if (wasRecentlyModified(`example-${payload.id}`)) return;
+      }
+
+      // Handle request deletion - mark open tabs as deleted
+      if (event === 'request:delete' && payload?.id) {
+        const tabId = `request-${payload.id}`;
+        if (wasRecentlyModified(tabId)) return;
+        const openTab = openTabs.find(t => t.id === tabId);
+        if (openTab) {
+          setDeletedTabs(prev => new Set([...prev, tabId]));
+        }
+      }
+
+      // Handle example deletion - mark open tabs as deleted
+      if (event === 'example:delete' && payload?.id) {
+        const tabId = `example-${payload.id}`;
+        if (wasRecentlyModified(tabId)) return;
+        const openTab = openTabs.find(t => t.id === tabId);
+        if (openTab) {
+          setDeletedTabs(prev => new Set([...prev, tabId]));
+        }
+      }
+
+      // Skip own collection modifications
+      if (
+        (event === 'collection:create' || event === 'collection:update' || event === 'collection:delete') &&
+        payload?.id && wasRecentlyModified(`collection-${payload.id}`)
+      ) return;
+
+      // Skip own request modifications
+      if (
+        (event === 'request:create' || event === 'request:update' || event === 'request:delete') &&
+        payload?.id && wasRecentlyModified(`request-${payload.id}`)
+      ) return;
+
+      // Skip own example modifications
+      if (
+        (event === 'example:create' || event === 'example:update' || event === 'example:delete') &&
+        payload?.id && wasRecentlyModified(`example-${payload.id}`)
+      ) return;
+
+      // Skip example events if parent request was recently modified (cascade delete)
+      if (event === 'example:delete' && payload?.request_id && wasRecentlyModified(`request-${payload.request_id}`)) return;
+
+      // Skip own import
+      if (event === 'sync:import' && payload?.rootCollectionId && wasRecentlyModified(`collection-${payload.rootCollectionId}`)) return;
+
+      // Handle delete events by updating state directly
+      if (event === 'collection:delete' && payload?.id) {
+        setCollections(prev => removeCollectionBranch(prev, payload.id));
+        return;
+      }
+
+      if (event === 'request:delete' && payload?.id) {
+        setCollections(prev => removeRequestFromState(prev, payload.id));
+        return;
+      }
+
+      if (event === 'collection:create' && payload?.id) {
+        setCollections(prev => upsertCollectionInState(prev, payload));
+        return;
+      }
+
+      if (event === 'collection:update' && payload?.id) {
+        setCollections(prev => upsertCollectionInState(prev, payload));
+        return;
+      }
+
+      if ((event === 'request:create' || event === 'request:update' || event === 'request:move') && payload?.id) {
+        data.getRequest(payload.id)
+          .then((request) => { setCollections(prev => upsertRequestInState(prev, request)); })
+          .catch((error) => { console.error(`Failed to sync websocket ${event}:`, error); });
+        return;
+      }
+
+      if (event === 'request:reorder' && payload?.id) {
+        data.getRequest(payload.id)
+          .then((request) => { setCollections(prev => upsertRequestInState(prev, request)); })
+          .catch((error) => { console.error('Failed to sync websocket request reorder:', error); });
+        return;
+      }
+
+      if (event === 'example:create' && payload?.id) {
+        const syncExampleCreate = async () => {
+          try {
+            const example = payload.request_id ? payload : await data.getExample(payload.id);
+            const fullExample = example.request_data ? example : await data.getExample(example.id);
+
+            setCollections(prev => patchRequestInState(prev, example.request_id, (request) => ({
+              ...request,
+              example_count: (request.example_count || 0) + 1,
+            })));
+
+            if (selectedRequest?.id === fullExample.request_id) {
+              setExamples(prev => upsertExampleInList(prev, fullExample));
+            }
+          } catch (error) {
+            console.error('Failed to sync websocket example create:', error);
+          }
+        };
+        syncExampleCreate();
+        return;
+      }
+
+      if (event === 'example:update' && payload?.id) {
+        const syncExampleUpdate = async () => {
+          try {
+            const example = await data.getExample(payload.id);
+            setCollections(prev => patchRequestInState(prev, example.request_id, (request) => ({ ...request })));
+            if (selectedRequest?.id === example.request_id) {
+              setExamples(prev => upsertExampleInList(prev, example));
+            }
+          } catch (error) {
+            console.error('Failed to sync websocket example update:', error);
+          }
+        };
+        syncExampleUpdate();
+        return;
+      }
+
+      if (event === 'example:delete' && payload?.id) {
+        const deletedExampleRequestId =
+          payload.request_id
+          || examples.find((example) => example.id === payload.id)?.request_id
+          || openTabs.find((tab) => tab.id === `example-${payload.id}`)?.parentRequestId
+          || null;
+
+        if (deletedExampleRequestId) {
+          setCollections(prev => patchRequestInState(prev, deletedExampleRequestId, (request) => ({
+            ...request,
+            example_count: Math.max(0, (request.example_count || 0) - 1),
+          })));
+        }
+
+        setExamples(prev => prev.filter((example) => example.id !== payload.id));
+        return;
+      }
+
+      if (event === 'sync:import') {
+        loadCollections();
+      }
+
+      if (
+        event === 'environment:create' || event === 'environment:update' || event === 'environment:delete' ||
+        event === 'environment:activate' || event === 'environment:deactivate'
+      ) {
+        if (activeWorkspace?.id) loadEnvironments(activeWorkspace.id);
+      }
+
+      // Workflow realtime events
+      if (event?.startsWith('workflow:')) {
+        loadWorkflows();
+        if (event === 'workflow:DELETE' && payload?.id) {
+          const tabId = `workflow-${payload.id}`;
+          const openTab = openTabs.find(t => t.id === tabId);
+          if (openTab) setDeletedTabs(prev => new Set([...prev, tabId]));
+        }
+      }
+    },
+    [activeWorkspace?.id, examples, loadCollections, loadEnvironments, loadWorkflows, openTabs, selectedRequest?.id, setCollections, setExamples, wasRecentlyModified, setConflictedTabs, setDeletedTabs]
+  );
+
+  return useWebSocket(handleWebSocketMessage);
+}

--- a/src/hooks/useSidebarDragDrop.js
+++ b/src/hooks/useSidebarDragDrop.js
@@ -1,0 +1,337 @@
+import { useState } from 'react';
+import { useToast } from '../components/Toast';
+import { useDragPreview } from './useDragPreview';
+import { METHOD_COLORS } from '../constants/methodColors';
+import * as data from '../data/index.js';
+
+export function useSidebarDragDrop(collections, getChildCollections, setCollections) {
+  const toast = useToast();
+  const setDragPreview = useDragPreview();
+
+  const [draggedRequest, setDraggedRequest] = useState(null);
+  const [dragOverRequest, setDragOverRequest] = useState(null);
+  const [draggedFolder, setDraggedFolder] = useState(null);
+  const [dragOverFolder, setDragOverFolder] = useState(null);
+  const [draggedExample, setDraggedExample] = useState(null);
+  const [dragOverExample, setDragOverExample] = useState(null);
+  const [dragOverCollection, setDragOverCollection] = useState(null);
+  const [folderDropZone, setFolderDropZone] = useState(null);
+
+  const getRootCollectionId = (collectionId) => {
+    let current = collections.find(c => c.id === collectionId);
+    while (current?.parent_id) {
+      current = collections.find(c => c.id === current.parent_id);
+    }
+    return current?.id;
+  };
+
+  const isSameRootCollection = (idA, idB) => {
+    return getRootCollectionId(idA) === getRootCollectionId(idB);
+  };
+
+  const isDescendant = (parentId, targetId) => {
+    const check = (id) => {
+      const children = collections.filter(c => c.parent_id === id);
+      for (const child of children) {
+        if (child.id === targetId) return true;
+        if (check(child.id)) return true;
+      }
+      return false;
+    };
+    return check(parentId);
+  };
+
+  // Request drag handlers
+  const handleDragStart = (e, request, collectionId) => {
+    setDraggedRequest({ ...request, collectionId });
+    e.dataTransfer.effectAllowed = 'copyMove';
+    e.dataTransfer.setData('text/plain', request.id);
+    e.dataTransfer.setData('text/x-request-id', request.id);
+    setDragPreview(e, `${request.method} ${request.name}`, METHOD_COLORS[request.method]);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedRequest(null);
+    setDragOverRequest(null);
+  };
+
+  const handleDragOver = (e, request, collectionId) => {
+    if (!draggedRequest || draggedRequest.id === request.id) return;
+    if (!isSameRootCollection(draggedRequest.collectionId, collectionId)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    if (draggedRequest.id !== request.id) {
+      setDragOverRequest(request.id);
+    }
+  };
+
+  const handleDragLeave = () => {
+    setDragOverRequest(null);
+  };
+
+  const handleDrop = async (e, targetRequest, collectionId, requests) => {
+    e.preventDefault();
+    setDragOverRequest(null);
+    setDragOverCollection(null);
+
+    if (!draggedRequest || draggedRequest.id === targetRequest.id) return;
+    if (!isSameRootCollection(draggedRequest.collectionId, collectionId)) return;
+
+    if (draggedRequest.collectionId !== collectionId) {
+      try {
+        await data.moveRequest(draggedRequest.id, collectionId);
+        const targetIds = requests.map(r => r.id);
+        const targetIndex = targetIds.indexOf(targetRequest.id);
+        targetIds.splice(targetIndex, 0, draggedRequest.id);
+        await data.reorderRequests(collectionId, targetIds);
+        // Optimistic update: move request between collections and apply new sort order
+        setCollections(prev => {
+          const movedReq = prev.flatMap(c => c.requests || []).find(r => r.id === draggedRequest.id);
+          if (!movedReq) return prev;
+          return prev.map(c => {
+            if (c.id === draggedRequest.collectionId) {
+              return { ...c, requests: (c.requests || []).filter(r => r.id !== draggedRequest.id) };
+            }
+            if (c.id === collectionId) {
+              const updated = [...(c.requests || []).filter(r => r.id !== draggedRequest.id)];
+              const tIdx = updated.findIndex(r => r.id === targetRequest.id);
+              updated.splice(tIdx >= 0 ? tIdx : updated.length, 0, { ...movedReq, collection_id: collectionId });
+              return { ...c, requests: updated.map((r, i) => ({ ...r, sort_order: i })) };
+            }
+            return c;
+          });
+        });
+        toast.success('Request moved');
+      } catch (err) {
+        toast.error('Failed to move request');
+      }
+      setDraggedRequest(null);
+      return;
+    }
+
+    const requestIds = requests.map(r => r.id);
+    const draggedIndex = requestIds.indexOf(draggedRequest.id);
+    const targetIndex = requestIds.indexOf(targetRequest.id);
+    requestIds.splice(draggedIndex, 1);
+    requestIds.splice(targetIndex, 0, draggedRequest.id);
+
+    try {
+      await data.reorderRequests(collectionId, requestIds);
+      // Optimistic update: apply new sort order to collection state
+      setCollections(prev => prev.map(c => {
+        if (c.id !== collectionId) return c;
+        const reordered = requestIds.map((id, i) => {
+          const req = (c.requests || []).find(r => r.id === id);
+          return req ? { ...req, sort_order: i } : null;
+        }).filter(Boolean);
+        return { ...c, requests: reordered };
+      }));
+      toast.success('Request reordered');
+    } catch (err) {
+      toast.error('Failed to reorder requests');
+    }
+
+    setDraggedRequest(null);
+  };
+
+  // Collection/folder drag handlers
+  const getFolderDropZone = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const ratio = y / rect.height;
+    if (ratio < 0.3) return 'before';
+    if (ratio > 0.7) return 'after';
+    return 'inside';
+  };
+
+  const handleCollectionDragOver = (e, collectionId) => {
+    if (!draggedRequest && !draggedFolder) return;
+    const dragSourceId = draggedRequest?.collectionId || draggedFolder?.parent_id;
+    if (dragSourceId && !isSameRootCollection(dragSourceId, collectionId)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+
+    if (draggedFolder && draggedFolder.id !== collectionId) {
+      const zone = getFolderDropZone(e);
+      setFolderDropZone(zone);
+      if (zone === 'inside') {
+        setDragOverCollection(collectionId);
+        setDragOverFolder(null);
+      } else {
+        setDragOverFolder(collectionId);
+        setDragOverCollection(null);
+      }
+    } else {
+      setDragOverCollection(collectionId);
+    }
+  };
+
+  const handleCollectionDragLeave = () => {
+    setDragOverCollection(null);
+    setDragOverFolder(null);
+    setFolderDropZone(null);
+  };
+
+  const handleCollectionDrop = async (e, collectionId, siblingCollections) => {
+    e.preventDefault();
+    const zone = folderDropZone;
+    setDragOverCollection(null);
+    setDragOverFolder(null);
+    setFolderDropZone(null);
+
+    if (draggedFolder) {
+      if (draggedFolder.id === collectionId) return;
+
+      const targetCollection = collections.find(c => c.id === collectionId);
+      const isSibling = draggedFolder.parent_id === targetCollection?.parent_id;
+      const targetParentId = targetCollection?.parent_id;
+
+      if (zone !== 'inside') {
+        if (isDescendant(draggedFolder.id, collectionId)) return;
+
+        if (!isSibling) {
+          if (draggedFolder.parent_id === targetParentId) { setDraggedFolder(null); return; }
+          try {
+            await data.moveCollection(draggedFolder.id, targetParentId);
+          } catch (err) {
+            toast.error('Failed to move folder');
+            setDraggedFolder(null);
+            return;
+          }
+        }
+
+        const newSiblings = isSibling ? siblingCollections : getChildCollections(targetParentId);
+        const ids = newSiblings.map(c => c.id);
+        const draggedIndex = ids.indexOf(draggedFolder.id);
+        if (draggedIndex !== -1) ids.splice(draggedIndex, 1);
+        let targetIndex = ids.indexOf(collectionId);
+        if (targetIndex === -1) { setDraggedFolder(null); return; }
+        if (zone === 'after') targetIndex += 1;
+        ids.splice(targetIndex, 0, draggedFolder.id);
+
+        try {
+          await data.reorderCollections(targetParentId, ids);
+          toast.success(isSibling ? 'Folder reordered' : 'Folder moved');
+        } catch (err) {
+          toast.error('Failed to reorder folders');
+        }
+        setDraggedFolder(null);
+        return;
+      }
+
+      if (draggedFolder.parent_id === collectionId) return;
+      if (isDescendant(draggedFolder.id, collectionId)) return;
+      try {
+        await data.moveCollection(draggedFolder.id, collectionId);
+        toast.success('Folder moved');
+      } catch (err) {
+        toast.error('Failed to move folder');
+      }
+      setDraggedFolder(null);
+      return;
+    }
+
+    if (!draggedRequest || draggedRequest.collectionId === collectionId) return;
+    try {
+      await data.moveRequest(draggedRequest.id, collectionId);
+      // Optimistic update: move request to target collection
+      setCollections(prev => {
+        const movedReq = prev.flatMap(c => c.requests || []).find(r => r.id === draggedRequest.id);
+        if (!movedReq) return prev;
+        return prev.map(c => {
+          if (c.id === draggedRequest.collectionId) {
+            return { ...c, requests: (c.requests || []).filter(r => r.id !== draggedRequest.id) };
+          }
+          if (c.id === collectionId) {
+            return { ...c, requests: [...(c.requests || []), { ...movedReq, collection_id: collectionId }] };
+          }
+          return c;
+        });
+      });
+      toast.success('Request moved');
+    } catch (err) {
+      toast.error('Failed to move request');
+    }
+    setDraggedRequest(null);
+  };
+
+  const handleFolderDragStart = (e, collection) => {
+    setDraggedFolder(collection);
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', collection.id);
+    setDragPreview(e, `📁 ${collection.name}`);
+  };
+
+  const handleFolderDragEnd = () => {
+    setDraggedFolder(null);
+    setDragOverFolder(null);
+    setDragOverCollection(null);
+    setFolderDropZone(null);
+  };
+
+  // Example drag handlers
+  const handleExampleDragStart = (e, example, requestId) => {
+    setDraggedExample({ ...example, requestId });
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', example.id);
+    e.stopPropagation();
+    setDragPreview(e, `📄 ${example.name}`);
+  };
+
+  const handleExampleDragEnd = () => {
+    setDraggedExample(null);
+    setDragOverExample(null);
+  };
+
+  const handleExampleDragOver = (e, example) => {
+    if (!draggedExample || draggedExample.id === example.id) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverExample(example.id);
+  };
+
+  const handleExampleDragLeave = () => {
+    setDragOverExample(null);
+  };
+
+  const handleExampleDrop = async (e, targetExample, requestId, examples) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverExample(null);
+
+    if (!draggedExample || draggedExample.id === targetExample.id) return;
+    if (draggedExample.requestId !== requestId) return;
+
+    const ids = examples.map(ex => ex.id);
+    const draggedIndex = ids.indexOf(draggedExample.id);
+    const targetIndex = ids.indexOf(targetExample.id);
+    if (draggedIndex === -1 || targetIndex === -1) return;
+
+    ids.splice(draggedIndex, 1);
+    ids.splice(targetIndex, 0, draggedExample.id);
+
+    try {
+      await data.reorderExamples(requestId, ids);
+    } catch (err) {
+      console.error('Failed to reorder examples:', err);
+    }
+
+    setDraggedExample(null);
+  };
+
+  return {
+    // State
+    draggedRequest, dragOverRequest, draggedFolder, dragOverFolder,
+    draggedExample, dragOverExample, dragOverCollection, folderDropZone,
+    // Request handlers
+    handleDragStart, handleDragEnd, handleDragOver, handleDragLeave, handleDrop,
+    // Collection/folder handlers
+    handleCollectionDragOver, handleCollectionDragLeave, handleCollectionDrop,
+    handleFolderDragStart, handleFolderDragEnd,
+    // Example handlers
+    handleExampleDragStart, handleExampleDragEnd, handleExampleDragOver,
+    handleExampleDragLeave, handleExampleDrop,
+    // Helpers
+    isSameRootCollection,
+  };
+}

--- a/src/hooks/useTauriClose.js
+++ b/src/hooks/useTauriClose.js
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import useModalStore from '../stores/modalStore';
+
+export function useTauriClose(userConfig) {
+  const { user } = useAuth();
+  const setShowCloseModal = useModalStore((s) => s.setShowCloseModal);
+  const userRef = useRef(null);
+  const closeBehaviorRef = useRef(null);
+
+  useEffect(() => { userRef.current = user; }, [user]);
+  useEffect(() => { closeBehaviorRef.current = userConfig.closeBehavior; }, [userConfig.closeBehavior]);
+
+  useEffect(() => {
+    if (!('__TAURI_INTERNALS__' in window)) return;
+    let unlisten;
+    let cancelled = false;
+    import('@tauri-apps/api/event').then(({ listen }) => {
+      if (cancelled) return;
+      listen('close-requested', async () => {
+        const { invoke } = await import('@tauri-apps/api/core');
+        if (!userRef.current) {
+          await invoke('close_app');
+        } else {
+          const behavior = closeBehaviorRef.current;
+          if (behavior === 'tray') {
+            await invoke('hide_window');
+          } else if (behavior === 'close') {
+            await invoke('close_app');
+          } else {
+            setShowCloseModal(true);
+          }
+        }
+      }).then(fn => { if (!cancelled) unlisten = fn; else fn(); });
+    });
+    return () => { cancelled = true; unlisten?.(); };
+  }, [setShowCloseModal]);
+}

--- a/src/hooks/useWebSocket.js
+++ b/src/hooks/useWebSocket.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { providerName, subscribeToChanges } from '../data/index.js';
 
 export function useWebSocket(onMessage) {
@@ -6,6 +6,8 @@ export function useWebSocket(onMessage) {
   const reconnectTimeoutRef = useRef(null);
   const onMessageRef = useRef(onMessage);
   const unsubscribeRef = useRef(null);
+  const [connected, setConnected] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
 
   // Keep the callback ref updated without triggering reconnects
   useEffect(() => {
@@ -29,6 +31,7 @@ export function useWebSocket(onMessage) {
         const event = `${table}:${normalizedEventType}`;
         onMessageRef.current({ event, data });
       });
+      setConnected(true);
 
       return () => {
         if (unsubscribeRef.current) {
@@ -46,6 +49,8 @@ export function useWebSocket(onMessage) {
 
       ws.onopen = () => {
         console.log('WebSocket connected');
+        setConnected(true);
+        setReconnecting(false);
       };
 
       ws.onmessage = (event) => {
@@ -60,6 +65,8 @@ export function useWebSocket(onMessage) {
 
       ws.onclose = () => {
         console.log('WebSocket disconnected, reconnecting...');
+        setConnected(false);
+        setReconnecting(true);
         reconnectTimeoutRef.current = setTimeout(connect, 2000);
       };
 
@@ -82,5 +89,5 @@ export function useWebSocket(onMessage) {
     };
   }, []); // Empty deps - only connect once on mount
 
-  return wsRef;
+  return { wsRef, connected, reconnecting };
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -41,18 +41,21 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { ErrorBoundary } from './components/ErrorBoundary.jsx'
 import { ToastProvider } from './components/Toast.jsx'
 import { ConfirmProvider } from './components/ConfirmModal.jsx'
 import { PromptProvider } from './components/PromptModal.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <ToastProvider>
-      <ConfirmProvider>
-        <PromptProvider>
-          <App />
-        </PromptProvider>
-      </ConfirmProvider>
-    </ToastProvider>
+    <ErrorBoundary>
+      <ToastProvider>
+        <ConfirmProvider>
+          <PromptProvider>
+            <App />
+          </PromptProvider>
+        </ConfirmProvider>
+      </ToastProvider>
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/src/stores/modalStore.js
+++ b/src/stores/modalStore.js
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+const useModalStore = create((set) => ({
+  // Modal visibility
+  showEnvEditor: false,
+  showImportCurl: false,
+  showSettings: false,
+  showAbout: false,
+  showCloseModal: false,
+
+  // Tab close modals
+  draftSavePending: null,
+  tempCloseTabId: null,
+  dirtyCloseTabId: null,
+
+  // Setters
+  setShowEnvEditor: (v) => set({ showEnvEditor: v }),
+  setShowImportCurl: (v) => set({ showImportCurl: v }),
+  setShowSettings: (v) => set({ showSettings: v }),
+  setShowAbout: (v) => set({ showAbout: v }),
+  setShowCloseModal: (v) => set({ showCloseModal: v }),
+  setDraftSavePending: (v) => set({ draftSavePending: v }),
+  setTempCloseTabId: (v) => set({ tempCloseTabId: v }),
+  setDirtyCloseTabId: (v) => set({ dirtyCloseTabId: v }),
+}));
+
+export default useModalStore;

--- a/src/styles/error-boundary.css
+++ b/src/styles/error-boundary.css
@@ -1,0 +1,93 @@
+/* ErrorBoundary fallback */
+.error-boundary-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: var(--bg-primary);
+  font-family: var(--font-sans);
+}
+
+.error-boundary-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-8);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  max-width: 420px;
+  text-align: center;
+}
+
+.error-boundary-icon {
+  color: var(--accent-danger);
+}
+
+.error-boundary-heading {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.error-boundary-message {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.error-boundary-reload {
+  padding: var(--space-2) var(--space-6);
+  background: var(--accent-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.error-boundary-reload:hover {
+  opacity: 0.85;
+}
+
+/* ConnectionStatus banner */
+.connection-status {
+  width: 100%;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.connection-status--connected {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--accent-success);
+}
+
+.connection-status--reconnecting {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--accent-warning);
+  animation: connection-pulse 1.5s ease-in-out infinite;
+}
+
+.connection-status--lost {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--accent-danger);
+}
+
+@keyframes connection-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}

--- a/src/utils/collectionState.js
+++ b/src/utils/collectionState.js
@@ -1,0 +1,97 @@
+export function sortRequests(requests) {
+  return [...requests].sort((a, b) => {
+    const sortA = a.sort_order ?? Number.MAX_SAFE_INTEGER;
+    const sortB = b.sort_order ?? Number.MAX_SAFE_INTEGER;
+    if (sortA !== sortB) return sortA - sortB;
+    return (a.created_at || 0) - (b.created_at || 0);
+  });
+}
+
+export function upsertCollectionInState(collections, collection) {
+  const existing = collections.find((item) => item.id === collection.id);
+  const nextCollection = {
+    ...existing,
+    ...collection,
+    requests: existing?.requests || [],
+  };
+
+  if (existing) {
+    return collections.map((item) => (item.id === collection.id ? nextCollection : item));
+  }
+
+  return [...collections, nextCollection].sort((a, b) => (a.created_at || 0) - (b.created_at || 0));
+}
+
+export function removeCollectionBranch(collections, collectionId) {
+  const idsToRemove = new Set([collectionId]);
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    collections.forEach((collection) => {
+      if (collection.parent_id && idsToRemove.has(collection.parent_id) && !idsToRemove.has(collection.id)) {
+        idsToRemove.add(collection.id);
+        changed = true;
+      }
+    });
+  }
+
+  return collections.filter((collection) => !idsToRemove.has(collection.id));
+}
+
+export function upsertRequestInState(collections, request) {
+  let existingRequest = null;
+
+  const collectionsWithoutRequest = collections.map((collection) => ({
+    ...collection,
+    requests: (collection.requests || []).filter((item) => {
+      if (item.id === request.id) {
+        existingRequest = item;
+        return false;
+      }
+      return true;
+    }),
+  }));
+
+  return collectionsWithoutRequest.map((collection) => {
+    if (collection.id !== request.collection_id) {
+      return collection;
+    }
+
+    const nextRequest = {
+      ...existingRequest,
+      ...request,
+      example_count: request.example_count ?? existingRequest?.example_count ?? 0,
+    };
+
+    return {
+      ...collection,
+      requests: sortRequests([...(collection.requests || []), nextRequest]),
+    };
+  });
+}
+
+export function removeRequestFromState(collections, requestId) {
+  return collections.map((collection) => ({
+    ...collection,
+    requests: (collection.requests || []).filter((request) => request.id !== requestId),
+  }));
+}
+
+export function patchRequestInState(collections, requestId, updater) {
+  return collections.map((collection) => ({
+    ...collection,
+    requests: (collection.requests || []).map((request) => (
+      request.id === requestId ? updater(request) : request
+    )),
+  }));
+}
+
+export function upsertExampleInList(examples, example) {
+  const existing = examples.find((item) => item.id === example.id);
+  if (existing) {
+    return examples.map((item) => (item.id === example.id ? { ...item, ...example } : item));
+  }
+
+  return [example, ...examples].sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+}

--- a/src/utils/jsonComments.js
+++ b/src/utils/jsonComments.js
@@ -1,0 +1,67 @@
+export function extractComments(text) {
+  const comments = [];
+  const stripped = text.replace(/"(?:[^"\\]|\\.)*"|\/\/.*$|\/\*[\s\S]*?\*\//gm, (match, offset) => {
+    if (match.startsWith('"')) return match;
+    if (match.startsWith('//')) {
+      const lineStart = text.lastIndexOf('\n', offset - 1) + 1;
+      const before = text.substring(lineStart, offset);
+      // Find the JSON key this comment is associated with (nearest "key": on the same line)
+      const keyMatch = before.match(/"([^"]+)"\s*:/);
+      if (keyMatch) {
+        comments.push({ key: keyMatch[1], text: match.trim() });
+      } else if (/^\s*[\]}],?\s*$/.test(before)) {
+        // Comment is on a closing bracket/brace line — find the key whose value just closed
+        // Scan backward: first } or ] sets depth=1, find its matching { or [ at depth=0
+        const textBefore = text.substring(0, offset);
+        let depth = 0;
+        let seenCloser = false;
+        for (let i = textBefore.length - 1; i >= 0; i--) {
+          const ch = textBefore[i];
+          if (ch === '}' || ch === ']') { depth++; seenCloser = true; }
+          else if (ch === '{' || ch === '[') depth--;
+          if (seenCloser && depth === 0) {
+            // Matched the opening bracket — look for the key before it
+            const preceding = textBefore.substring(0, i);
+            const ownerMatch = preceding.match(/"([^"]+)"\s*:\s*$/);
+            if (ownerMatch) {
+              comments.push({ key: ownerMatch[1], text: match.trim() });
+            }
+            break;
+          }
+        }
+      }
+      return ' '.repeat(match.length);
+    }
+    return ' '.repeat(match.length);
+  });
+  return { stripped, comments };
+}
+
+export function reinsertComments(formatted, comments) {
+  if (comments.length === 0) return formatted;
+  const lines = formatted.split('\n');
+  for (const { key, text } of comments) {
+    const keyPattern = `"${key}"`;
+    const idx = lines.findIndex(l => l.includes(keyPattern));
+    if (idx === -1) continue;
+    // Check if value opens an array/object on this line
+    const afterKey = lines[idx].substring(lines[idx].indexOf(keyPattern) + keyPattern.length);
+    const opensBlock = /:\s*[\[{]\s*$/.test(afterKey);
+    if (opensBlock) {
+      // Find the matching closing bracket/brace
+      const opener = afterKey.trim().slice(-1);
+      const closer = opener === '[' ? ']' : '}';
+      let depth = 1;
+      for (let i = idx + 1; i < lines.length && depth > 0; i++) {
+        for (const ch of lines[i]) {
+          if (ch === opener) depth++;
+          else if (ch === closer) depth--;
+          if (depth === 0) { lines[i] = lines[i] + ' ' + text; break; }
+        }
+      }
+    } else {
+      lines[idx] = lines[idx] + ' ' + text;
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/utils/jsonEditorTheme.js
+++ b/src/utils/jsonEditorTheme.js
@@ -1,0 +1,133 @@
+import { EditorView } from '@codemirror/view';
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags } from '@lezer/highlight';
+
+export const baseTheme = EditorView.theme({
+  '&': {
+    backgroundColor: 'var(--bg-input)',
+    color: 'var(--text-primary)',
+    fontSize: '13px',
+    fontFamily: 'var(--font-mono)',
+  },
+  '.cm-content': {
+    caretColor: 'var(--accent-primary)',
+    padding: '12px 4px',
+  },
+  '.cm-cursor': {
+    borderLeftColor: 'var(--accent-primary)',
+  },
+  '.cm-selectionMatch': {
+    backgroundColor: 'rgba(59, 130, 246, 0.2)',
+  },
+  '.cm-activeLine': {
+    backgroundColor: 'transparent',
+  },
+  '&.cm-focused .cm-activeLine': {
+    backgroundColor: 'rgba(128, 128, 128, 0.08)',
+  },
+  '.cm-gutters': {
+    backgroundColor: 'var(--bg-input)',
+    color: 'var(--text-tertiary)',
+    border: 'none',
+    borderRight: '1px solid var(--border-subtle)',
+  },
+  '.cm-activeLineGutter': {
+    backgroundColor: 'transparent',
+  },
+  '&.cm-focused .cm-activeLineGutter': {
+    backgroundColor: 'rgba(128, 128, 128, 0.08)',
+  },
+  '.cm-lineNumbers .cm-gutterElement': {
+    padding: '0 8px 0 12px',
+    minWidth: '32px',
+  },
+  '.cm-scroller': {
+    fontFamily: 'var(--font-mono)',
+    lineHeight: '1.6',
+  },
+  '.cm-foldPlaceholder': {
+    backgroundColor: 'var(--bg-tertiary)',
+    border: '1px solid var(--border-primary)',
+    color: 'var(--text-tertiary)',
+  },
+  '.cm-matchingBracket': {
+    backgroundColor: 'var(--accent-primary-subtle)',
+    outline: '1px solid var(--accent-primary)',
+  },
+  '.cm-placeholder': {
+    color: 'var(--text-tertiary)',
+    fontStyle: 'italic',
+  },
+  '.cm-lintRange-error': {
+    backgroundImage: 'none',
+    textDecoration: 'underline wavy var(--accent-danger)',
+    textDecorationSkipInk: 'none',
+    textUnderlineOffset: '2px',
+  },
+  '.cm-tooltip.cm-tooltip-lint': {
+    backgroundColor: 'var(--bg-elevated)',
+    border: '1px solid var(--border-primary)',
+    borderRadius: 'var(--radius-sm)',
+    boxShadow: 'var(--shadow-lg)',
+    fontFamily: 'var(--font-sans)',
+    fontSize: '12px',
+    padding: '0',
+  },
+  '.cm-diagnostic-error': {
+    color: 'var(--accent-danger)',
+    borderLeft: '3px solid var(--accent-danger)',
+    padding: '6px 10px',
+    margin: '0',
+  },
+  '.cm-gutter-lint': {
+    width: '14px',
+  },
+  '.cm-gutter-lint .cm-gutterElement': {
+    padding: '0',
+  },
+});
+
+export const lightSyntaxHighlight = syntaxHighlighting(HighlightStyle.define([
+  { tag: tags.string, color: '#16a34a' },
+  { tag: tags.number, color: '#d97706' },
+  { tag: tags.bool, color: '#7c3aed' },
+  { tag: tags.null, color: '#dc2626' },
+  { tag: tags.propertyName, color: '#0284c7' },
+  { tag: tags.punctuation, color: '#64748b' },
+  { tag: tags.brace, color: '#64748b' },
+  { tag: tags.squareBracket, color: '#64748b' },
+]));
+
+export const lightSelection = EditorView.theme({
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+    backgroundColor: 'rgba(37, 99, 235, 0.4) !important',
+  },
+  '.cm-line ::selection': {
+    backgroundColor: 'rgba(37, 99, 235, 0.45) !important',
+    color: '#1e293b !important',
+  },
+  '.cm-content': {
+    caretColor: 'var(--accent-primary)',
+  },
+});
+
+export const darkSyntaxHighlight = syntaxHighlighting(HighlightStyle.define([
+  { tag: tags.string, color: '#4ade80' },
+  { tag: tags.number, color: '#fbbf24' },
+  { tag: tags.bool, color: '#a78bfa' },
+  { tag: tags.null, color: '#f87171' },
+  { tag: tags.propertyName, color: '#38bdf8' },
+  { tag: tags.punctuation, color: '#94a3b8' },
+  { tag: tags.brace, color: '#94a3b8' },
+  { tag: tags.squareBracket, color: '#94a3b8' },
+]));
+
+export const darkSelection = EditorView.theme({
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+    backgroundColor: 'rgba(96, 165, 250, 0.45) !important',
+  },
+  '.cm-line ::selection': {
+    backgroundColor: 'rgba(96, 165, 250, 0.5) !important',
+    color: '#f1f5f9 !important',
+  },
+});

--- a/src/utils/jsonLinter.js
+++ b/src/utils/jsonLinter.js
@@ -1,0 +1,85 @@
+import { linter } from '@codemirror/lint';
+import jsonlint from 'jsonlint-mod';
+
+export function createJsonLinter() {
+  return linter((view) => {
+    const doc = view.state.doc;
+    const text = doc.toString();
+    if (!text.trim()) return [];
+
+    const envVarRegex = /"?\{\{([^}]+)\}\}"?/g;
+    let safeText = text.replace(envVarRegex, (match) => {
+      const len = match.length;
+      if (len < 2) return match;
+      return '"' + 'a'.repeat(len - 2) + '"';
+    });
+
+    // Strip comments (JSON5 supports them, but jsonlint doesn't)
+    // Match strings first to skip them, then replace comments with spaces to preserve positions
+    safeText = safeText.replace(/"(?:[^"\\]|\\.)*"|\/\/.*$|\/\*[\s\S]*?\*\//gm, (match) => {
+      if (match.startsWith('"')) return match;
+      return match.replace(/[^\n]/g, ' ');
+    });
+
+    try {
+      jsonlint.parse(safeText);
+      return [];
+    } catch (e) {
+      const errMsg = e.message || '';
+      const lines = errMsg.split('\n');
+
+      // Extract line number: "Parse error on line N:"
+      const lineMatch = errMsg.match(/line (\d+)/);
+      // Extract "Expecting ..., got ..." message
+      const expectingLine = lines.find(l => /^Expecting\s/.test(l));
+      // Extract column from caret pointer line
+      const ptrLine = lines.find(l => l.includes('^'));
+      const errorCol = ptrLine ? ptrLine.indexOf('^') : 0;
+
+      let message = errMsg.split('\n')[0];
+      if (expectingLine) {
+        const gotMatch = expectingLine.match(/got\s+'([^']+)'/);
+        const got = gotMatch ? gotMatch[1] : '';
+        const tokenNames = { STRING: 'string', NUMBER: 'number', NULL: 'null', TRUE: 'true', FALSE: 'false', EOF: 'end of input', undefined: 'unexpected token' };
+        const gotLabel = tokenNames[got] || `'${got}'`;
+        const expected = [];
+        const tokenRegex = /'([^']*)'/g;
+        const expectPart = expectingLine.replace(/,\s*got\s+.*$/, '');
+        let m;
+        while ((m = tokenRegex.exec(expectPart)) !== null) {
+          if (m[1] !== 'EOF') expected.push(m[1]);
+        }
+        const isValue = (t) => ['STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '['].includes(t);
+        const has = (t) => expected.includes(t);
+
+        if (has(',') && has(':')) message = got === 'STRING' ? 'Expected comma' : "Expected ':' after property name";
+        else if (has(',')) message = 'Expected comma';
+        else if (has(':')) message = "Expected ':' after property name";
+        else if (has('STRING') && has('}') && !has('NUMBER')) message = got === ',' ? 'Unexpected comma' : `Expected property name or '}'`;
+        else if (expected.some(isValue) && (got === '}' || got === ']')) message = 'Trailing comma is not allowed';
+        else if (expected.some(isValue)) message = `Expected a value, got ${gotLabel}`;
+        else message = `Unexpected ${gotLabel}`;
+      }
+
+      if (!lineMatch) return [];
+      const errorLine = parseInt(lineMatch[1], 10);
+
+      if (errorLine < 1 || errorLine > doc.lines) {
+        const lastLine = doc.line(doc.lines);
+        const trimmed = lastLine.text.trimEnd();
+        const from = lastLine.from + Math.max(0, trimmed.length - 1);
+        const to = lastLine.from + Math.max(trimmed.length, 1);
+        return [{ from, to: Math.min(to, doc.length), severity: 'error', message }];
+      }
+
+      const line = doc.line(errorLine);
+      const from = line.from + Math.min(errorCol, line.length);
+
+      let to = line.from + line.text.trimEnd().length;
+      if (to <= from) to = Math.min(from + 1, line.to);
+      to = Math.min(to, doc.length);
+
+      return [{ from, to, severity: 'error', message }];
+    }
+  }, { delay: 300 });
+}


### PR DESCRIPTION
## Summary
- Add global `ErrorBoundary` with fallback UI and `ConnectionStatus` WebSocket banner
- Refactor App.jsx (1270→619 lines), Sidebar.jsx (1275→995 lines), JsonEditor.jsx (473→183 lines) by extracting hooks, utils, and components
- Fix drag-and-drop reorder/move not updating UI (added optimistic state updates)
- Fix JSON comment preservation on closing bracket lines (`},` comments survive beautify)
- Add E2E tests for drag-and-drop reorder and move operations

## Changes

### New files
| File | Purpose |
|------|---------|
| `ErrorBoundary.jsx` | React error boundary with reload fallback |
| `ConnectionStatus.jsx` | WebSocket disconnect/reconnect banner |
| `CurlPanel.jsx` | cURL preview panel (from App.jsx) |
| `useRealtimeSync.js` | WebSocket message routing (from App.jsx) |
| `useClipboardLinks.js` | Shared link detection (from App.jsx) |
| `useCollectionVariables.js` | Collection variable loading (from App.jsx) |
| `useTauriClose.js` | Desktop close behavior (from App.jsx) |
| `useSidebarDragDrop.js` | Drag-and-drop logic with optimistic updates (from Sidebar.jsx) |
| `modalStore.js` | Zustand store for modal visibility |
| `collectionState.js` | Collection state helper functions |
| `jsonLinter.js`, `jsonComments.js`, `jsonEditorTheme.js` | JsonEditor utils |

### Bug fixes
- **Drag-and-drop UI not updating**: reorder/move relied on WebSocket events to refresh UI; now updates state optimistically after API success
- **JSON comments on closing brackets**: `}, // comment` now survives beautify by tracing bracket nesting to find the owning key

## Test plan
- [x] All 51 E2E tests passing
- [x] New tests: error boundary (2), drag-and-drop reorder (1), drag-and-drop move to subfolder (1)
- [x] Manual verification: drag reorder updates immediately, move to subfolder works, JSON comment on `}` line preserved

Closes #14