### PR TITLE
feat: persist MCP sessions across server restarts

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -1,6 +1,7 @@
 # Supabase
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Server
 PORT=3100

--- a/mcp-server/src/auth/routes.ts
+++ b/mcp-server/src/auth/routes.ts
@@ -195,7 +195,7 @@ authRouter.get('/auth/redirect-info', (req: Request, res: Response) => {
 });
 
 // Token endpoint — exchanges auth code for access token
-authRouter.post('/token', (req: Request, res: Response) => {
+authRouter.post('/token', async (req: Request, res: Response) => {
   const { grant_type, code, code_verifier, redirect_uri, client_id } = req.body;
 
   if (grant_type !== 'authorization_code') {
@@ -234,7 +234,7 @@ authRouter.post('/token', (req: Request, res: Response) => {
   // Generate a long-lived MCP token that maps to the Supabase session
   const mcpToken = randomBytes(48).toString('hex');
 
-  storeSession(mcpToken, {
+  await storeSession(mcpToken, {
     supabaseRefreshToken: auth.supabaseRefreshToken!,
     cachedAccessToken: auth.supabaseAccessToken!,
     expiresAt: auth.supabaseExpiresAt || Math.floor(Date.now() / 1000) + 3600,

--- a/mcp-server/src/lib/supabase.ts
+++ b/mcp-server/src/lib/supabase.ts
@@ -2,13 +2,23 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
 const SUPABASE_URL = process.env.SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error('Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables');
 }
 
+if (!SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable (required for session persistence)');
+}
+
 // Admin client for token operations (uses anon key, not service role)
 export const adminClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Service role client for mcp_sessions table (bypasses RLS)
+const serviceClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
 });
 
@@ -31,23 +41,74 @@ interface StoredSession {
   email: string;
 }
 
-const sessions = new Map<string, StoredSession>();
+// In-memory cache for read performance (avoids DB query on every /mcp request)
+const sessionCache = new Map<string, { session: StoredSession; cachedAt: number }>();
+const CACHE_TTL = 60_000; // 1 minute
 
-export function storeSession(mcpToken: string, session: StoredSession) {
-  sessions.set(mcpToken, session);
+export async function storeSession(mcpToken: string, session: StoredSession) {
+  const now = Math.floor(Date.now() / 1000);
+  await serviceClient.from('mcp_sessions').upsert({
+    token: mcpToken,
+    user_id: session.userId,
+    email: session.email,
+    refresh_token: session.supabaseRefreshToken,
+    access_token: session.cachedAccessToken,
+    expires_at: session.expiresAt,
+    created_at: now,
+    last_used_at: now,
+  });
+  sessionCache.set(mcpToken, { session, cachedAt: Date.now() });
 }
 
-export function getStoredSession(mcpToken: string): StoredSession | undefined {
-  return sessions.get(mcpToken);
+export async function getStoredSession(mcpToken: string): Promise<StoredSession | undefined> {
+  // Check cache first
+  const cached = sessionCache.get(mcpToken);
+  if (cached && Date.now() - cached.cachedAt < CACHE_TTL) {
+    return cached.session;
+  }
+
+  const { data } = await serviceClient
+    .from('mcp_sessions')
+    .select('*')
+    .eq('token', mcpToken)
+    .single();
+
+  if (!data) {
+    sessionCache.delete(mcpToken);
+    return undefined;
+  }
+
+  const session: StoredSession = {
+    supabaseRefreshToken: data.refresh_token,
+    cachedAccessToken: data.access_token,
+    expiresAt: data.expires_at,
+    userId: data.user_id,
+    email: data.email,
+  };
+  sessionCache.set(mcpToken, { session, cachedAt: Date.now() });
+  return session;
 }
 
-export function deleteSession(mcpToken: string) {
-  sessions.delete(mcpToken);
+export async function deleteSession(mcpToken: string) {
+  sessionCache.delete(mcpToken);
+  await serviceClient.from('mcp_sessions').delete().eq('token', mcpToken);
+}
+
+// Update session in DB after token refresh
+async function updateSessionTokens(mcpToken: string, session: StoredSession) {
+  const now = Math.floor(Date.now() / 1000);
+  await serviceClient.from('mcp_sessions').update({
+    refresh_token: session.supabaseRefreshToken,
+    access_token: session.cachedAccessToken,
+    expires_at: session.expiresAt,
+    last_used_at: now,
+  }).eq('token', mcpToken);
+  sessionCache.set(mcpToken, { session, cachedAt: Date.now() });
 }
 
 // Get a valid Supabase client for an MCP token, refreshing if needed
 export async function getAuthenticatedClient(mcpToken: string): Promise<{ client: SupabaseClient; userId: string } | null> {
-  const stored = getStoredSession(mcpToken);
+  const stored = await getStoredSession(mcpToken);
   if (!stored) return null;
 
   const now = Math.floor(Date.now() / 1000);
@@ -63,7 +124,7 @@ export async function getAuthenticatedClient(mcpToken: string): Promise<{ client
   });
 
   if (error || !data.session) {
-    sessions.delete(mcpToken);
+    await deleteSession(mcpToken);
     return null;
   }
 
@@ -72,7 +133,16 @@ export async function getAuthenticatedClient(mcpToken: string): Promise<{ client
   stored.supabaseRefreshToken = data.session.refresh_token;
   stored.expiresAt = data.session.expires_at || now + 3600;
 
+  // Persist refreshed tokens to DB
+  await updateSessionTokens(mcpToken, stored);
+
   return { client: createUserClient(stored.cachedAccessToken), userId: stored.userId };
 }
+
+// Cleanup: delete sessions unused for 30 days (runs every 6 hours)
+setInterval(async () => {
+  const cutoff = Math.floor(Date.now() / 1000) - 30 * 86400;
+  await serviceClient.from('mcp_sessions').delete().lt('last_used_at', cutoff);
+}, 6 * 3600_000);
 
 export { SUPABASE_URL, SUPABASE_ANON_KEY };

--- a/supabase/migrations/20260402000000_mcp_sessions.sql
+++ b/supabase/migrations/20260402000000_mcp_sessions.sql
@@ -1,0 +1,14 @@
+-- Persistent MCP sessions: survives server restarts
+CREATE TABLE mcp_sessions (
+  token         TEXT PRIMARY KEY,
+  user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  email         TEXT NOT NULL,
+  refresh_token TEXT NOT NULL,
+  access_token  TEXT NOT NULL,
+  expires_at    BIGINT NOT NULL,
+  created_at    BIGINT NOT NULL DEFAULT extract(epoch FROM now())::bigint,
+  last_used_at  BIGINT NOT NULL DEFAULT extract(epoch FROM now())::bigint
+);
+
+ALTER TABLE mcp_sessions ENABLE ROW LEVEL SECURITY;
+-- No policies: only service role can access (protects refresh tokens)


### PR DESCRIPTION
## Summary
- Replace in-memory session `Map` with Supabase `mcp_sessions` table so MCP tokens survive server restarts
- Users no longer need to re-authenticate after deployments
- Zero change to user-facing OAuth flow or MCP protocol

## Changes
- **Migration:** `mcp_sessions` table (token PK, user_id FK with CASCADE, RLS enabled, service role only)
- **Session store:** DB-backed `storeSession`/`getStoredSession`/`deleteSession` with 60s in-memory cache
- **Token refresh:** persists new Supabase tokens to DB after refresh
- **Cleanup:** periodic job deletes sessions unused for 30+ days
- **New env var:** `SUPABASE_SERVICE_ROLE_KEY` (required)

## Deployment note
Add `SUPABASE_SERVICE_ROLE_KEY` to the MCP server environment before deploying. The server will fail to start without it.

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Migration applies clean (`supabase db reset`)
- [x] Table accessible via service role REST API
- [x] No changes to OAuth flow or MCP endpoints

Closes #16