### PR TITLE
release: v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.1.11
+
+### New
+
+- **Global Console Panel** — Console logs are now a persistent bottom panel instead of a per-request tab in the Response Viewer. Logs from all request executions are collected globally, tagged with request name and timestamp. Includes clear and close buttons. (#18)
+- **Embedded Terminal** — Full interactive terminal (PowerShell on Windows, bash on Mac/Linux) embedded in the bottom panel. Supports multiple simultaneous terminals with tabs, restart, and theme-synced colors. Tauri desktop app only. (#18)
+- **Bottom Status Bar** — Persistent bar at the bottom of the window with Console and Terminal toggle buttons, log count badge, and error indicator.
+- **Global Error Boundary** — React error boundary wraps the app with a fallback UI ("Something went wrong" + Reload button). WebSocket connection status banner shows reconnecting/disconnected state. (#14)
+- **MCP Session Persistence** — MCP server sessions now survive server restarts. Tokens stored in a `mcp_sessions` Supabase table instead of in-memory. Users no longer need to re-authenticate after deployments. (#16)
+
+### Improved
+
+- **Code Architecture** — Major refactoring of the two largest files:
+  - `App.jsx` reduced from 1,270 to 619 lines — extracted `useRealtimeSync`, `useClipboardLinks`, `useCollectionVariables`, `useTauriClose` hooks, `CurlPanel` component, and `modalStore`
+  - `Sidebar.jsx` reduced from 1,275 to 995 lines — extracted `useSidebarDragDrop` hook with all drag-and-drop logic
+  - `JsonEditor.jsx` reduced from 473 to 183 lines — extracted `jsonLinter`, `jsonComments`, `jsonEditorTheme` utils
+- **Drag & Drop Reorder** — Fixed forward-drag placing items at wrong position (off by one). Added optimistic UI updates so reorder/move reflects immediately without waiting for WebSocket events.
+- **Sidebar Resize Handle** — Changed from 3px transparent gap to 1px border line for a cleaner look.
+
+### Fixed
+
+- **JSON Comment Preservation** — Comments on closing bracket lines (`}, // comment`) now survive beautify. Previously only inline comments on key-value lines were preserved. (#13)
+- **Drag Reorder Not Updating UI** — Reordering or moving requests via drag-and-drop now updates the sidebar immediately via optimistic state updates, independent of WebSocket/Realtime connection status.
+- **Missing Import** — Fixed `syncCloseBehaviorToRust` not imported in refactored `App.jsx`, which would crash Tauri desktop users with saved close behavior preferences.
+
 ## v0.1.10
 
 ### New

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-umbrella"
-version = "0.1.10"
+version = "0.1.11"
 description = "A self-hosted API testing tool"
 authors = ["emonster"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Post Umbrella",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "ca.emonster.post-umbrella",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v0.1.11

### New
- **Global Console Panel** — persistent bottom panel replacing per-request console tab (#18)
- **Embedded Terminal** — xterm.js + PTY, multi-tab, Tauri desktop only (#18)
- **Bottom Status Bar** — Console/Terminal toggle with log count badge
- **Global Error Boundary** — fallback UI + WebSocket connection banner (#14)
- **MCP Session Persistence** — tokens survive server restarts (#16)

### Improved
- **App.jsx** 1,270 → 619 lines, **Sidebar.jsx** 1,275 → 995 lines, **JsonEditor.jsx** 473 → 183 lines
- **Drag & Drop** — fixed forward-drag off-by-one, added optimistic UI updates
- **Sidebar resize handle** — 3px gap → 1px border

### Fixed
- JSON comment preservation on closing bracket lines (#13)
- Drag reorder not updating UI without WebSocket
- Missing `syncCloseBehaviorToRust` import in refactored App.jsx