### PR TITLE
release: v0.1.12 — image preview, sidebar search/collapse, cURL inherited auth/vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.1.12
+
+### New
+
+- **Image Response Preview** — Responses with `image/*` content types (PNG, JPEG, WebP, GIF, SVG) now render inline as an actual image in the Response Viewer instead of dumping raw binary text. Edge Function proxy, browser-direct fetch path, and the Tauri desktop `http_request` command all base64-encode binary bodies so the bytes survive the JS bridge intact. (#21)
+
+### Improved
+
+- **Sidebar Expand/Collapse Works During Search** — Clicking expand-all or collapse-all while a search query is active now actually does something. Typing a query auto-expands matching branches; expand-all unfolds all matching collections + their ancestors; collapse-all folds them back to headers only. As a side benefit, expand-all without a search now recurses into nested subfolders too (previously only root-level). (#21)
+- **Copy as cURL Honors Inherited Auth & Variables** — When a request uses "Inherit from Parent" auth, the cURL output now includes the parent collection's Bearer token. When a token contains `{{variable}}`, both environment and collection variables are substituted (environment wins on conflicts). (#21)
+
+### Fixed
+
+- **New Variable Values Were Silently Dropped** — Adding a new environment or collection variable in the editor was saving the variable with an empty value due to a reference-equality bug in the `isNew` detection (`editingVars.indexOf(v)` against a mapped copy always returned -1). Values now persist correctly on first save.
+- **Env Vars Truly Override Collection Vars** — When both an environment variable and a collection variable defined the same key, the previous substitution loop replaced the collection value first, erasing the `{{key}}` pattern before the environment value could win. Substitution now uses a single-pass merged map so environment values reliably override.
+- **Optimistic Collection Save** — Saving auth or pre/post scripts on a collection now updates the in-memory collection list immediately, so the cURL preview and auth inheritance reflect the change without waiting for the realtime broadcast round-trip.
+
 ## v0.1.11
 
 ### New

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "post-umbrella"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-umbrella"
-version = "0.1.11"
+version = "0.1.12"
 description = "A self-hosted API testing tool"
 authors = ["emonster"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Post Umbrella",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "identifier": "ca.emonster.post-umbrella",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
v0.1.12 release rolling up the issue #21 improvements (already merged via #22) plus the in-path bug fixes that surfaced during that work.

### New
- **Image Response Preview** — Responses with `image/*` content types render inline as an actual image instead of dumping raw binary text. All three response paths now base64-encode binary bodies (Edge Function proxy, browser-direct fetch, Tauri desktop \`http_request\`).

### Improved
- **Sidebar Expand/Collapse Works During Search** — Both toolbar buttons now operate on the visible filtered tree. Bonus: expand-all without a search now recurses into nested subfolders.
- **Copy as cURL Honors Inherited Auth & Variables** — Resolves \`auth_type = inherit\` against the parent chain and substitutes both environment and collection variables (env wins on conflicts).

### Fixed
- New env/collection variable values were silently dropped due to a reference-equality bug in \`isNew\` detection.
- Env vars truly override collection vars now (single-pass merged-map substitution; previous order erased the \`{{key}}\` pattern before the override could happen).
- Optimistic update on collection auth/script save so the cURL preview and inheritance reflect immediately without waiting for realtime.

## Version bumps
- \`src-tauri/tauri.conf.json\` 0.1.11 → 0.1.12
- \`src-tauri/Cargo.toml\` 0.1.11 → 0.1.12
- \`src-tauri/Cargo.lock\` 0.1.11 → 0.1.12

## Test plan
- [x] Image preview verified end-to-end against \`https://picsum.photos/200/300\` in Tauri desktop and via E2E (\`e2e/image-preview.spec.ts\` asserts \`naturalWidth > 0\`).
- [x] cURL panel E2E (4/4 passing): inherited auth, env-var token, collection-var token, env-overrides-collection.
- [x] Sidebar E2E (3/3 passing): expand-all/collapse-all with search, individual toggle while searching, expand-all recurses into nested.
- [x] Regression suites pass: collection-auth, environment, collection-variables, request, request-editor, collection, workflow.