### PR TITLE
ci: cleanup old releases workflow (keep last N)

### DIFF
--- a/.github/workflows/cleanup-old-releases.yml
+++ b/.github/workflows/cleanup-old-releases.yml
@@ -1,0 +1,64 @@
+name: Cleanup Old Releases
+
+# Runs when a release is published (manually or via the release.yml workflow).
+# Keeps the N most recent published releases and deletes the rest along with
+# their git tags. Drafts and prereleases are ignored.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      keep:
+        description: 'Number of recent releases to keep'
+        required: false
+        default: '2'
+
+env:
+  KEEP: ${{ github.event.inputs.keep || '2' }}
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old releases and tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          KEEP_COUNT="${KEEP:-2}"
+          echo "Keeping the $KEEP_COUNT most recent published releases."
+
+          # List published (non-draft, non-prerelease) releases newest-first by createdAt.
+          TAGS=$(gh release list --limit 100 \
+            --json tagName,isDraft,isPrerelease,createdAt \
+            --jq 'map(select(.isDraft == false and .isPrerelease == false))
+                  | sort_by(.createdAt) | reverse | map(.tagName) | .[]')
+
+          if [ -z "$TAGS" ]; then
+            echo "No published releases found."
+            exit 0
+          fi
+
+          echo "Found releases (newest first):"
+          echo "$TAGS"
+          echo "---"
+
+          INDEX=0
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            INDEX=$((INDEX + 1))
+            if [ "$INDEX" -le "$KEEP_COUNT" ]; then
+              echo "Keeping #$INDEX: $tag"
+              continue
+            fi
+            echo "Deleting #$INDEX: $tag (release + tag)"
+            gh release delete "$tag" --yes --cleanup-tag
+          done <<< "$TAGS"
+
+          echo "Cleanup complete."


### PR DESCRIPTION
## Summary
New workflow `.github/workflows/cleanup-old-releases.yml` that fires when a release is published and prunes older releases + their tags.

- **Trigger:** \`release.published\` (also \`workflow_dispatch\` with an input \`keep\`)
- **Default keep count:** 2 (most recent published releases)
- **Ignored:** drafts and prereleases — these never cause cleanup, never get deleted
- **Action:** \`gh release delete <tag> --yes --cleanup-tag\` (removes both release and the underlying git tag)

Why \`release.published\` rather than \`build success\`: the existing release.yml creates a *draft* release. Triggering cleanup on draft creation would delete the previous release before you've confirmed the new build is good. Publishing a release is an explicit "this is the new latest" signal — that's the right moment to prune.

## Test plan
- [ ] Manually trigger via Actions → "Cleanup Old Releases" → Run workflow with \`keep = 99\` first to verify it lists releases without deleting anything.
- [ ] Then re-run with \`keep = 2\` to actually prune.
- [ ] Confirm subsequent published release auto-prunes the oldest beyond the keep count.