### PR TITLE
feat: PDF preview + Preview/Raw/Hex toggle for image and PDF (#25)

### DIFF
--- a/acceptance/binary-raw-hex-toggle.md
+++ b/acceptance/binary-raw-hex-toggle.md
@@ -1,0 +1,236 @@
+# Acceptance Spec: Preview / Raw / Hex Toggle for Image and PDF
+
+## Problem
+HTML responses have a Preview / Raw toggle. Image and PDF responses have only one view (rendered) — there's no way to inspect the bytes. Users debugging "why isn't this rendering?" or copying base64 fixtures into tests need a Raw and Hex view.
+
+## Scope
+- `src/components/ResponseViewer.jsx`
+- `src/styles/response-viewer.css`
+- New tiny component `src/components/BinaryViewToggle.jsx` (segmented [Preview | Raw | Hex] control)
+
+Out of scope:
+- Adding the toggle to HTML preview (HTML already has a Preview / Raw of its own; not changing it).
+- Other binary types (audio, video) — separate follow-up.
+- Editing the raw view (read-only).
+
+## Interface Contract
+
+### New component: `src/components/BinaryViewToggle.jsx`
+```jsx
+import { Eye, FileText, Hash } from 'lucide-react';
+
+export function BinaryViewToggle({ value, onChange, testIdPrefix }) {
+  return (
+    <div className="option-selector binary-view-toggle" data-testid={`${testIdPrefix}-view-toggle`}>
+      <button
+        className={value === 'preview' ? 'active' : ''}
+        onClick={() => onChange('preview')}
+        data-testid={`${testIdPrefix}-preview-btn`}
+      >
+        <Eye size={12} /> Preview
+      </button>
+      <button
+        className={value === 'raw' ? 'active' : ''}
+        onClick={() => onChange('raw')}
+        data-testid={`${testIdPrefix}-raw-btn`}
+      >
+        <FileText size={12} /> Raw
+      </button>
+      <button
+        className={value === 'hex' ? 'active' : ''}
+        onClick={() => onChange('hex')}
+        data-testid={`${testIdPrefix}-hex-btn`}
+      >
+        <Hash size={12} /> Hex
+      </button>
+    </div>
+  );
+}
+```
+
+### Hex dump helper (place in `ResponseViewer.jsx` or a small util)
+```js
+const HEX_VIEW_BYTE_CAP = 1024 * 1024; // 1 MB
+
+// Decode body (base64 string OR raw-binary string) → Uint8Array
+function decodeToBytes(body) {
+  if (typeof body !== 'string' || !body) return new Uint8Array();
+  const cleaned = body.replace(/\s+/g, '');
+  // base64?
+  if (/^[A-Za-z0-9+/]+={0,2}$/.test(cleaned) && cleaned.length % 4 === 0) {
+    try {
+      const bin = atob(cleaned);
+      const out = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+      return out;
+    } catch { /* fall through */ }
+  }
+  // Raw-binary string fallback (each char is a byte)
+  const out = new Uint8Array(body.length);
+  for (let i = 0; i < body.length; i++) out[i] = body.charCodeAt(i) & 0xff;
+  return out;
+}
+
+// Render up to `byteLimit` bytes as `addr | hex | ascii` rows.
+// Returns { text, truncated, totalBytes }.
+function buildHexDump(bytes, byteLimit = HEX_VIEW_BYTE_CAP) {
+  const total = bytes.length;
+  const cap = Math.min(total, byteLimit);
+  const lines = [];
+  for (let off = 0; off < cap; off += 16) {
+    const slice = bytes.subarray(off, Math.min(off + 16, cap));
+    const addr = off.toString(16).padStart(8, '0');
+    const hex = Array.from(slice).map(b => b.toString(16).padStart(2, '0')).join(' ').padEnd(47, ' ');
+    const ascii = Array.from(slice).map(b => (b >= 0x20 && b < 0x7f) ? String.fromCharCode(b) : '.').join('');
+    lines.push(`${addr}  ${hex}  ${ascii}`);
+  }
+  return { text: lines.join('\n'), truncated: total > cap, totalBytes: total };
+}
+```
+
+### State (in `ResponseViewer`)
+```js
+const [imageViewMode, setImageViewMode] = useState('preview');
+const [pdfViewMode, setPdfViewMode] = useState('preview');
+const [hexShowAll, setHexShowAll] = useState(false);
+
+// Reset on response change
+useEffect(() => {
+  setImageViewMode('preview');
+  setPdfViewMode('preview');
+  setHexShowAll(false);
+}, [displayResponse]);
+```
+
+### Updated render branches
+
+**Image branch:**
+```jsx
+) : isImageBody ? (
+  <>
+    <BinaryViewToggle value={imageViewMode} onChange={setImageViewMode} testIdPrefix="image" />
+    {imageViewMode === 'preview' && (
+      <div className="image-preview-container" data-testid="image-preview-container">
+        <img className="image-preview" src={buildBinaryDataUrl(displayResponse?.body, imageMimeType)} alt="Response image" data-testid="image-preview" onError={(e) => { e.currentTarget.dataset.failed = 'true'; }} />
+      </div>
+    )}
+    {imageViewMode === 'raw' && (
+      <pre className="binary-raw-view" data-testid="image-raw-body">{displayResponse?.body}</pre>
+    )}
+    {imageViewMode === 'hex' && (
+      <HexView body={displayResponse?.body} showAll={hexShowAll} onShowAll={() => setHexShowAll(true)} testId="image-hex-body" />
+    )}
+  </>
+```
+
+**PDF branch:** identical structure, swapping image with the `<object>` from F1 and using `pdfViewMode` / `testIdPrefix="pdf"`.
+
+### `HexView` sub-component
+```jsx
+function HexView({ body, showAll, onShowAll, testId }) {
+  const { text, truncated, totalBytes } = useMemo(() => {
+    const bytes = decodeToBytes(body);
+    return buildHexDump(bytes, showAll ? Infinity : HEX_VIEW_BYTE_CAP);
+  }, [body, showAll]);
+  return (
+    <div className="binary-hex-view-wrapper">
+      <pre className="binary-hex-view" data-testid={testId}>{text}</pre>
+      {truncated && (
+        <div className="binary-hex-truncated">
+          Showing first {HEX_VIEW_BYTE_CAP.toLocaleString()} bytes of {totalBytes.toLocaleString()}.{' '}
+          <button className="link-button" onClick={onShowAll} data-testid={`${testId}-show-all`}>Show all</button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+### CSS additions
+```css
+.binary-view-toggle {
+  margin-bottom: var(--space-2);
+}
+.binary-raw-view,
+.binary-hex-view {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre;
+  overflow: auto;
+  padding: var(--space-3);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  margin: 0;
+  height: 100%;
+}
+.binary-raw-view {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.binary-hex-view-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+.binary-hex-truncated {
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-secondary);
+  font-size: 12px;
+  border-top: 1px solid var(--border-primary);
+  background: var(--bg-tertiary);
+}
+.link-button {
+  background: none;
+  border: none;
+  color: var(--accent-primary);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
+}
+```
+
+## Acceptance Criteria
+
+### AC1 — Image branch shows the toggle
+For an image response, `[data-testid="image-view-toggle"]` is visible with three buttons (Preview / Raw / Hex). Default selection is Preview.
+
+### AC2 — Image Raw view
+Clicking `[data-testid="image-raw-btn"]` swaps the `<img>` for `[data-testid="image-raw-body"]` containing the base64 body string. The `<img>` is gone.
+
+### AC3 — Image Hex view
+Clicking `[data-testid="image-hex-btn"]` swaps to `[data-testid="image-hex-body"]` containing rows in `addr  hex  ascii` format. Each row begins with an 8-digit hex address.
+
+### AC4 — PDF branch shows the toggle (depends on PDF F1)
+For a PDF response, `[data-testid="pdf-view-toggle"]` is visible. Same Preview / Raw / Hex behavior.
+
+### AC5 — Switching views does not re-fetch
+Switching Preview ↔ Raw ↔ Hex updates the body content area without refetching the request (no network call).
+
+### AC6 — Hex truncation at 1MB
+For a body whose decoded size exceeds 1MB, Hex view shows the first 1MB and a `[data-testid="<prefix>-hex-body-show-all"]` button. Clicking it expands to the full dump.
+
+### AC7 — View resets on new response
+After sending a fresh request, the view toggle resets to `Preview` (so the user always lands on the visual view first).
+
+### AC8 — Toggle visual matches existing `.option-selector`
+Same pill-segmented style as `.html-view-toggle`. Reuses `.option-selector` base class.
+
+### AC9 — Regressions
+- HTML preview Preview / Raw toggle unchanged
+- JSON, plain text, examples, and the desktop-agent banner branch unchanged
+- `e2e/image-preview.spec.ts` and `e2e/html-preview.spec.ts` still pass (the image-preview test only asserts the `<img>` shows when in Preview mode — the default — so it continues to pass)
+
+## Test Plan
+
+### E2E — extend `e2e/image-preview.spec.ts` and `e2e/pdf-preview.spec.ts`
+
+1. **image-view-toggle-raw** — Send image request; click Raw button; assert `[data-testid="image-raw-body"]` visible with non-empty text content; assert `[data-testid="image-preview"]` not visible.
+2. **image-view-toggle-hex** — Click Hex; assert `[data-testid="image-hex-body"]` visible; assert text matches `/^[0-9a-f]{8}\s+[0-9a-f]{2}/i` for the first row.
+3. **image-view-toggle-back-to-preview** — Click Hex then Preview; assert `[data-testid="image-preview"]` visible again with non-empty src.
+4. **pdf-view-toggle-raw / hex** — same as 1 & 2 for PDF.
+
+### Regression
+- `e2e/image-preview.spec.ts` JPEG test still passes (Preview is default).
+- `e2e/html-preview.spec.ts` unchanged.

--- a/acceptance/pdf-response-preview.md
+++ b/acceptance/pdf-response-preview.md
@@ -1,0 +1,127 @@
+# Acceptance Spec: PDF Response Preview
+
+## Problem
+Responses with `Content-Type: application/pdf` currently fall through to the raw `<pre>` branch in `ResponseViewer.jsx`, dumping a base64 string. Bytes are already delivered correctly (proxy + Tauri + browser-direct paths all base64-encode `application/pdf` since v0.1.12). Only the render branch is missing.
+
+## Scope
+Only `src/components/ResponseViewer.jsx` and `src/styles/response-viewer.css`. No data-layer or proxy changes.
+
+Out of scope:
+- A toggle (Preview / Raw / Hex) — that's F2 in the same issue.
+- Editing PDF responses in the example editor.
+- Custom JS-based PDF viewer (pdf.js, etc.). Use the browser's built-in renderer.
+
+## Interface Contract
+
+### MIME detection
+```js
+const isPdfResponse = (headers) => {
+  if (!Array.isArray(headers)) return false;
+  const ct = headers.find(h => h.key?.toLowerCase() === 'content-type')?.value;
+  return !!ct && /^\s*application\/pdf/i.test(ct);
+};
+```
+
+### Memo + flag (place near `imageMimeType`)
+```js
+const isPdfBody = useMemo(
+  () => !isExample && isPdfResponse(displayResponse?.headers),
+  [isExample, displayResponse?.headers]
+);
+```
+
+### Data-URL builder
+Mirror `buildImageSrc` — accept body that may already be a data URL, valid base64, or raw-binary string. Return `data:application/pdf;base64,...`. Refactor opportunity: rename `buildImageSrc` → `buildBinaryDataUrl(body, mimeType)` and reuse for both PDF and image. Pure refactor — same logic.
+
+### Render branch
+Insert between `isImageBody` and `isJsonBody` branches:
+```jsx
+) : isPdfBody ? (
+  <div className="pdf-preview-container" data-testid="pdf-preview-container">
+    <object
+      className="pdf-preview-frame"
+      data={buildBinaryDataUrl(displayResponse?.body, 'application/pdf')}
+      type="application/pdf"
+      data-testid="pdf-preview-frame"
+    >
+      <div className="pdf-preview-fallback" data-testid="pdf-preview-fallback">
+        <p>Your browser cannot display this PDF inline.</p>
+        <a
+          href={buildBinaryDataUrl(displayResponse?.body, 'application/pdf')}
+          download="response.pdf"
+        >
+          Download PDF
+        </a>
+      </div>
+    </object>
+  </div>
+) : isJsonBody ? (
+  ...existing
+```
+
+`<object>` chosen over `<iframe>` because it supports nested fallback content (the download link) that browsers without a PDF viewer will render automatically.
+
+### CSS (append to `src/styles/response-viewer.css`)
+```css
+.pdf-preview-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+.pdf-preview-frame {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg-tertiary);
+}
+.pdf-preview-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  color: var(--text-secondary);
+  text-align: center;
+  width: 100%;
+}
+.pdf-preview-fallback a {
+  color: var(--accent-primary);
+  text-decoration: underline;
+}
+```
+
+## Acceptance Criteria
+
+### AC1 — `application/pdf` renders inline
+Given a response with `Content-Type: application/pdf` and a base64 PDF body, the body tab MUST render `[data-testid="pdf-preview-container"]` containing an `<object data-testid="pdf-preview-frame">`. No raw `<pre>` of the base64 string.
+
+### AC2 — Content-Type with parameters detected
+`Content-Type: application/pdf; charset=binary` is detected as PDF.
+
+### AC3 — Already-`data:` body passes through unchanged
+If `body` already starts with `data:application/pdf`, the `<object data>` attribute uses it as-is (no double-wrapping).
+
+### AC4 — Browsers without inline PDF support fall back
+If the browser cannot render the PDF inline (e.g., macOS WKWebView in the Tauri desktop app), the nested fallback content (`[data-testid="pdf-preview-fallback"]`) becomes visible with a working download link. (Difficult to verify in E2E; covered by code review.)
+
+### AC5 — Non-PDF responses unaffected
+JSON, HTML, image, plain text, and example responses continue to render via their existing branches. No regression.
+
+### AC6 — Refactored helper preserves image behavior
+`buildImageSrc` rename to `buildBinaryDataUrl(body, mimeType)` — image preview uses the renamed function and still passes all `e2e/image-preview.spec.ts` cases.
+
+## Test Plan
+
+### E2E test — `e2e/pdf-preview.spec.ts` (new file)
+
+1. **pdf-preview-renders** — Create a request to a stable PDF URL (e.g., `https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf` — a 13KB W3C-hosted dummy PDF; if unreliable, use `https://pdfobject.com/pdf/sample.pdf`). Send, assert `[data-testid="pdf-preview-container"]` visible, `<object data-testid="pdf-preview-frame">` has `data` attribute starting with `data:application/pdf;base64,`. Skip browser-PDF-renders assertion (object's internal rendering isn't introspectable in Playwright).
+2. **pdf-preview-fallback-not-pdf** — Send a JSON request, assert `[data-testid="pdf-preview-container"]` is NOT visible.
+
+### Regression
+- `e2e/image-preview.spec.ts` — must still pass after the `buildImageSrc` → `buildBinaryDataUrl` rename.
+- `e2e/html-preview.spec.ts` — unchanged path.

--- a/e2e/binary-toggle.spec.ts
+++ b/e2e/binary-toggle.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTestCollections } from './helpers/cleanup';
+
+const timestamp = Date.now();
+const uniqueName = (base: string) => `${base} ${timestamp}`;
+
+test.afterAll(async () => { await cleanupTestCollections(timestamp); });
+
+async function createTestRequest(page, collectionName: string) {
+  const addCollectionBtn = page.locator('.sidebar-toolbar .btn-icon').last();
+  await expect(addCollectionBtn).toBeEnabled({ timeout: 10000 });
+  await addCollectionBtn.click();
+
+  const promptModal = page.locator('.prompt-modal');
+  await expect(promptModal).toBeVisible({ timeout: 5000 });
+  await promptModal.locator('.prompt-input').fill(collectionName);
+  await promptModal.locator('.prompt-btn-confirm').click();
+  await expect(promptModal).not.toBeVisible();
+
+  const collectionHeader = page.locator('.collection-header').filter({ hasText: collectionName });
+  await expect(collectionHeader).toBeVisible({ timeout: 5000 });
+  await collectionHeader.hover();
+  await collectionHeader.locator('.btn-menu').click();
+
+  const collectionMenu = page.locator('.collection-menu');
+  await expect(collectionMenu).toBeVisible();
+  await collectionMenu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+
+  const requestItem = page.locator('.request-item').filter({ hasText: 'New Request' }).first();
+  await expect(requestItem).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+}
+
+async function sendRequestAndWaitForResponse(page) {
+  const sendButton = page.locator('.btn-send');
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+
+  const responseViewer = page.locator('.response-viewer').first();
+  await expect(responseViewer).toBeVisible({ timeout: 30000 });
+  await expect(responseViewer.locator('.response-meta')).toBeVisible({ timeout: 30000 });
+  await expect(page.locator('.response-viewer.loading')).not.toBeVisible({ timeout: 30000 });
+}
+
+test.describe('Binary view toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+    await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('image-toggle-raw: clicking Raw shows raw body and hides image preview', async ({ page }) => {
+    const collectionName = uniqueName('Image Toggle Raw Collection');
+    await createTestRequest(page, collectionName);
+
+    await page.locator('.url-input').fill('https://picsum.photos/200/300');
+    await sendRequestAndWaitForResponse(page);
+
+    const imagePreview = page.locator('[data-testid="image-preview"]');
+    await expect(imagePreview).toBeVisible({ timeout: 20000 });
+
+    await page.locator('[data-testid="image-raw-btn"]').click();
+
+    const rawBody = page.locator('[data-testid="image-raw-body"]');
+    await expect(rawBody).toBeVisible({ timeout: 10000 });
+
+    const rawText = await rawBody.textContent();
+    expect(rawText).toBeTruthy();
+    expect(rawText!.trim().length).toBeGreaterThan(0);
+
+    await expect(imagePreview).not.toBeVisible();
+  });
+
+  test('image-toggle-hex: clicking Hex shows hex dump with address/byte format', async ({ page }) => {
+    const collectionName = uniqueName('Image Toggle Hex Collection');
+    await createTestRequest(page, collectionName);
+
+    await page.locator('.url-input').fill('https://picsum.photos/200/300');
+    await sendRequestAndWaitForResponse(page);
+
+    const imagePreview = page.locator('[data-testid="image-preview"]');
+    await expect(imagePreview).toBeVisible({ timeout: 20000 });
+
+    await page.locator('[data-testid="image-hex-btn"]').click();
+
+    const hexBody = page.locator('[data-testid="image-hex-body"]');
+    await expect(hexBody).toBeVisible({ timeout: 10000 });
+
+    const hexText = await hexBody.textContent();
+    expect(hexText).toBeTruthy();
+    const firstLine = hexText!.split('\n')[0];
+    expect(firstLine).toMatch(/^[0-9a-f]{8}\s+[0-9a-f]{2}/i);
+  });
+
+  test('image-toggle-back-to-preview: from hex view, clicking Preview restores image', async ({ page }) => {
+    const collectionName = uniqueName('Image Toggle Back Collection');
+    await createTestRequest(page, collectionName);
+
+    await page.locator('.url-input').fill('https://picsum.photos/200/300');
+    await sendRequestAndWaitForResponse(page);
+
+    const imagePreview = page.locator('[data-testid="image-preview"]');
+    await expect(imagePreview).toBeVisible({ timeout: 20000 });
+
+    // Switch to hex view first
+    await page.locator('[data-testid="image-hex-btn"]').click();
+    await expect(page.locator('[data-testid="image-hex-body"]')).toBeVisible({ timeout: 10000 });
+    await expect(imagePreview).not.toBeVisible();
+
+    // Now switch back to preview
+    await page.locator('[data-testid="image-preview-btn"]').click();
+
+    await expect(imagePreview).toBeVisible({ timeout: 10000 });
+    const src = await imagePreview.getAttribute('src');
+    expect(src).toBeTruthy();
+    expect(src!.length).toBeGreaterThan(0);
+  });
+
+  test('pdf-toggle-raw: clicking Raw on PDF response shows raw body text', async ({ page }) => {
+    const collectionName = uniqueName('PDF Toggle Raw Collection');
+    await createTestRequest(page, collectionName);
+
+    await page.locator('.url-input').fill('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
+    await sendRequestAndWaitForResponse(page);
+
+    // Wait for PDF branch to render the toggle
+    await expect(page.locator('[data-testid="pdf-view-toggle"]')).toBeVisible({ timeout: 20000 });
+
+    await page.locator('[data-testid="pdf-raw-btn"]').click();
+
+    const rawBody = page.locator('[data-testid="pdf-raw-body"]');
+    await expect(rawBody).toBeVisible({ timeout: 10000 });
+
+    const rawText = await rawBody.textContent();
+    expect(rawText).toBeTruthy();
+    expect(rawText!.trim().length).toBeGreaterThan(0);
+  });
+
+  test('pdf-toggle-hex: clicking Hex on PDF shows hex dump starting with %PDF magic bytes', async ({ page }) => {
+    const collectionName = uniqueName('PDF Toggle Hex Collection');
+    await createTestRequest(page, collectionName);
+
+    await page.locator('.url-input').fill('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
+    await sendRequestAndWaitForResponse(page);
+
+    // Wait for PDF branch to render the toggle
+    await expect(page.locator('[data-testid="pdf-view-toggle"]')).toBeVisible({ timeout: 20000 });
+
+    await page.locator('[data-testid="pdf-hex-btn"]').click();
+
+    const hexBody = page.locator('[data-testid="pdf-hex-body"]');
+    await expect(hexBody).toBeVisible({ timeout: 10000 });
+
+    const hexText = await hexBody.textContent();
+    expect(hexText).toBeTruthy();
+    const firstLine = hexText!.split('\n')[0];
+    // General hex row format
+    expect(firstLine).toMatch(/^[0-9a-f]{8}\s+[0-9a-f]{2}/i);
+    // PDFs always start with 25 50 44 46 ("%PDF")
+    expect(firstLine.startsWith('00000000  25 50 44 46')).toBe(true);
+  });
+});

--- a/e2e/pdf-preview.spec.ts
+++ b/e2e/pdf-preview.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { cleanupTestCollections } from './helpers/cleanup';
+
+const timestamp = Date.now();
+const uniqueName = (base: string) => `${base} ${timestamp}`;
+
+test.afterAll(async () => { await cleanupTestCollections(timestamp); });
+
+async function createTestRequest(page, collectionName: string) {
+  const addCollectionBtn = page.locator('.sidebar-toolbar .btn-icon').last();
+  await expect(addCollectionBtn).toBeEnabled({ timeout: 10000 });
+  await addCollectionBtn.click();
+
+  const promptModal = page.locator('.prompt-modal');
+  await expect(promptModal).toBeVisible({ timeout: 5000 });
+  await promptModal.locator('.prompt-input').fill(collectionName);
+  await promptModal.locator('.prompt-btn-confirm').click();
+  await expect(promptModal).not.toBeVisible();
+
+  const collectionHeader = page.locator('.collection-header').filter({ hasText: collectionName });
+  await expect(collectionHeader).toBeVisible({ timeout: 5000 });
+  await collectionHeader.hover();
+  await collectionHeader.locator('.btn-menu').click();
+
+  const collectionMenu = page.locator('.collection-menu');
+  await expect(collectionMenu).toBeVisible();
+  await collectionMenu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+
+  const requestItem = page.locator('.request-item').filter({ hasText: 'New Request' }).first();
+  await expect(requestItem).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+}
+
+async function sendRequestAndWaitForResponse(page) {
+  const sendButton = page.locator('.btn-send');
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+
+  const responseViewer = page.locator('.response-viewer').first();
+  await expect(responseViewer).toBeVisible({ timeout: 30000 });
+  await expect(responseViewer.locator('.response-meta')).toBeVisible({ timeout: 30000 });
+  await expect(page.locator('.response-viewer.loading')).not.toBeVisible({ timeout: 30000 });
+}
+
+test.describe('PDF Response Preview', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+    await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('pdf-preview-renders: application/pdf response renders inline in an <object>', async ({ page }) => {
+    const collectionName = uniqueName('PDF Preview Collection');
+    await createTestRequest(page, collectionName);
+
+    // Stable, small W3C-hosted dummy PDF (~13KB).
+    await page.locator('.url-input').fill('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
+    await sendRequestAndWaitForResponse(page);
+
+    const pdfContainer = page.locator('[data-testid="pdf-preview-container"]');
+    await expect(pdfContainer).toBeVisible({ timeout: 20000 });
+
+    const pdfFrame = page.locator('[data-testid="pdf-preview-frame"]');
+    await expect(pdfFrame).toBeVisible();
+
+    // The <object> data attribute should be a base64 data URL with the PDF mime type.
+    // We cannot introspect what the browser's built-in PDF viewer renders inside the <object>.
+    const dataAttr = await pdfFrame.getAttribute('data');
+    expect(dataAttr).toBeTruthy();
+    expect(dataAttr!).toMatch(/^data:application\/pdf;base64,/);
+  });
+
+  test('pdf-preview-fallback-not-pdf: JSON response does not render PDF preview', async ({ page }) => {
+    const collectionName = uniqueName('PDF Fallback JSON Collection');
+    await createTestRequest(page, collectionName);
+
+    // Small reliable JSON endpoint — should not trigger the PDF branch.
+    await page.locator('.url-input').fill('https://jsonplaceholder.typicode.com/posts/1');
+    await sendRequestAndWaitForResponse(page);
+
+    const pdfContainer = page.locator('[data-testid="pdf-preview-container"]');
+    await expect(pdfContainer).not.toBeVisible({ timeout: 5000 });
+
+    const jsonSurface = page.locator('.json-view-wrapper, .json-editor-wrapper, .cm-editor');
+    await expect(jsonSurface.first()).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/components/BinaryViewToggle.jsx
+++ b/src/components/BinaryViewToggle.jsx
@@ -1,5 +1,3 @@
-import { Eye, FileText, Hash } from 'lucide-react';
-
 export function BinaryViewToggle({ value, onChange, testIdPrefix }) {
   return (
     <div className="option-selector binary-view-toggle" data-testid={`${testIdPrefix}-view-toggle`}>
@@ -8,21 +6,21 @@ export function BinaryViewToggle({ value, onChange, testIdPrefix }) {
         onClick={() => onChange('preview')}
         data-testid={`${testIdPrefix}-preview-btn`}
       >
-        <Eye size={12} /> Preview
+        Preview
       </button>
       <button
         className={value === 'raw' ? 'active' : ''}
         onClick={() => onChange('raw')}
         data-testid={`${testIdPrefix}-raw-btn`}
       >
-        <FileText size={12} /> Raw
+        Raw
       </button>
       <button
         className={value === 'hex' ? 'active' : ''}
         onClick={() => onChange('hex')}
         data-testid={`${testIdPrefix}-hex-btn`}
       >
-        <Hash size={12} /> Hex
+        Hex
       </button>
     </div>
   );

--- a/src/components/BinaryViewToggle.jsx
+++ b/src/components/BinaryViewToggle.jsx
@@ -1,0 +1,29 @@
+import { Eye, FileText, Hash } from 'lucide-react';
+
+export function BinaryViewToggle({ value, onChange, testIdPrefix }) {
+  return (
+    <div className="option-selector binary-view-toggle" data-testid={`${testIdPrefix}-view-toggle`}>
+      <button
+        className={value === 'preview' ? 'active' : ''}
+        onClick={() => onChange('preview')}
+        data-testid={`${testIdPrefix}-preview-btn`}
+      >
+        <Eye size={12} /> Preview
+      </button>
+      <button
+        className={value === 'raw' ? 'active' : ''}
+        onClick={() => onChange('raw')}
+        data-testid={`${testIdPrefix}-raw-btn`}
+      >
+        <FileText size={12} /> Raw
+      </button>
+      <button
+        className={value === 'hex' ? 'active' : ''}
+        onClick={() => onChange('hex')}
+        data-testid={`${testIdPrefix}-hex-btn`}
+      >
+        <Hash size={12} /> Hex
+      </button>
+    </div>
+  );
+}

--- a/src/components/ResponseViewer.jsx
+++ b/src/components/ResponseViewer.jsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { Monitor, Download, Terminal } from 'lucide-react';
 import JsonView from '@uiw/react-json-view';
 import { JsonEditor } from './JsonEditor';
+import { BinaryViewToggle } from './BinaryViewToggle';
 
 const isHtmlResponse = (headers) => {
   if (!Array.isArray(headers)) return false;
@@ -19,9 +20,15 @@ const getImageMimeType = (headers) => {
   return match ? match[1].toLowerCase() : null;
 };
 
+const isPdfResponse = (headers) => {
+  if (!Array.isArray(headers)) return false;
+  const ct = headers.find(h => h.key?.toLowerCase() === 'content-type')?.value;
+  return !!ct && /^\s*application\/pdf/i.test(ct);
+};
+
 // body may be a data URL, a base64 string, a raw-binary string (lossy utf-8 decoded),
-// or an SVG source. Returns a valid <img> src for any of these.
-function buildImageSrc(body, mimeType) {
+// or an SVG source. Returns a valid data URL for any of these.
+function buildBinaryDataUrl(body, mimeType) {
   if (typeof body !== 'string' || !body || !mimeType) return '';
   if (body.startsWith('data:')) return body;
   // SVG is text — inline it so it doesn't need base64 decoding
@@ -39,6 +46,58 @@ function buildImageSrc(body, mimeType) {
   } catch {
     return '';
   }
+}
+
+const HEX_VIEW_BYTE_CAP = 1024 * 1024; // 1 MB
+
+// Decode body (base64 string OR raw-binary string) -> Uint8Array
+function decodeToBytes(body) {
+  if (typeof body !== 'string' || !body) return new Uint8Array();
+  const cleaned = body.replace(/\s+/g, '');
+  if (/^[A-Za-z0-9+/]+={0,2}$/.test(cleaned) && cleaned.length % 4 === 0) {
+    try {
+      const bin = atob(cleaned);
+      const out = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+      return out;
+    } catch { /* fall through */ }
+  }
+  const out = new Uint8Array(body.length);
+  for (let i = 0; i < body.length; i++) out[i] = body.charCodeAt(i) & 0xff;
+  return out;
+}
+
+// Render up to `byteLimit` bytes as `addr | hex | ascii` rows.
+function buildHexDump(bytes, byteLimit = HEX_VIEW_BYTE_CAP) {
+  const total = bytes.length;
+  const cap = Math.min(total, byteLimit);
+  const lines = [];
+  for (let off = 0; off < cap; off += 16) {
+    const slice = bytes.subarray(off, Math.min(off + 16, cap));
+    const addr = off.toString(16).padStart(8, '0');
+    const hex = Array.from(slice).map(b => b.toString(16).padStart(2, '0')).join(' ').padEnd(47, ' ');
+    const ascii = Array.from(slice).map(b => (b >= 0x20 && b < 0x7f) ? String.fromCharCode(b) : '.').join('');
+    lines.push(`${addr}  ${hex}  ${ascii}`);
+  }
+  return { text: lines.join('\n'), truncated: total > cap, totalBytes: total };
+}
+
+function HexView({ body, showAll, onShowAll, testId }) {
+  const { text, truncated, totalBytes } = useMemo(() => {
+    const bytes = decodeToBytes(body);
+    return buildHexDump(bytes, showAll ? Infinity : HEX_VIEW_BYTE_CAP);
+  }, [body, showAll]);
+  return (
+    <div className="binary-hex-view-wrapper">
+      <pre className="binary-hex-view" data-testid={testId}>{text}</pre>
+      {truncated && (
+        <div className="binary-hex-truncated">
+          Showing first {HEX_VIEW_BYTE_CAP.toLocaleString()} bytes of {totalBytes.toLocaleString()}.{' '}
+          <button className="link-button" onClick={onShowAll} data-testid={`${testId}-show-all`}>Show all</button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 const isTauri = () => '__TAURI_INTERNALS__' in window;
@@ -68,6 +127,9 @@ const isLocalOrPrivateUrl = (url) => {
 export function ResponseViewer({ response, loading, isExample, example, onExampleChange, requestUrl }) {
   const [activeTab, setActiveTab] = useState('body');
   const [htmlViewMode, setHtmlViewMode] = useState('preview');
+  const [imageViewMode, setImageViewMode] = useState('preview');
+  const [pdfViewMode, setPdfViewMode] = useState('preview');
+  const [hexShowAll, setHexShowAll] = useState(false);
 
   // For examples, use example.response_data
   const displayResponse = isExample ? example?.response_data : response;
@@ -75,6 +137,13 @@ export function ResponseViewer({ response, loading, isExample, example, onExampl
   // Reset htmlViewMode to 'preview' when displayResponse changes
   useEffect(() => {
     setHtmlViewMode('preview');
+  }, [displayResponse]);
+
+  // Reset binary view modes + hex expansion when a new response arrives
+  useEffect(() => {
+    setImageViewMode('preview');
+    setPdfViewMode('preview');
+    setHexShowAll(false);
   }, [displayResponse]);
 
   // Parse JSON body - must be before any early returns!
@@ -102,6 +171,11 @@ export function ResponseViewer({ response, loading, isExample, example, onExampl
     return getImageMimeType(displayResponse?.headers);
   }, [isExample, displayResponse?.headers]);
   const isImageBody = !!imageMimeType;
+
+  const isPdfBody = useMemo(
+    () => !isExample && isPdfResponse(displayResponse?.headers),
+    [isExample, displayResponse?.headers]
+  );
 
   if (loading) {
     return (
@@ -298,15 +372,66 @@ export function ResponseViewer({ response, loading, isExample, example, onExampl
               )}
             </>
           ) : isImageBody ? (
-            <div className="image-preview-container" data-testid="image-preview-container">
-              <img
-                className="image-preview"
-                src={buildImageSrc(displayResponse?.body, imageMimeType)}
-                alt="Response image"
-                data-testid="image-preview"
-                onError={(e) => { e.currentTarget.dataset.failed = 'true'; }}
-              />
-            </div>
+            <>
+              <BinaryViewToggle value={imageViewMode} onChange={setImageViewMode} testIdPrefix="image" />
+              {imageViewMode === 'preview' && (
+                <div className="image-preview-container" data-testid="image-preview-container">
+                  <img
+                    className="image-preview"
+                    src={buildBinaryDataUrl(displayResponse?.body, imageMimeType)}
+                    alt="Response image"
+                    data-testid="image-preview"
+                    onError={(e) => { e.currentTarget.dataset.failed = 'true'; }}
+                  />
+                </div>
+              )}
+              {imageViewMode === 'raw' && (
+                <pre className="binary-raw-view" data-testid="image-raw-body">{displayResponse?.body}</pre>
+              )}
+              {imageViewMode === 'hex' && (
+                <HexView
+                  body={displayResponse?.body}
+                  showAll={hexShowAll}
+                  onShowAll={() => setHexShowAll(true)}
+                  testId="image-hex-body"
+                />
+              )}
+            </>
+          ) : isPdfBody ? (
+            <>
+              <BinaryViewToggle value={pdfViewMode} onChange={setPdfViewMode} testIdPrefix="pdf" />
+              {pdfViewMode === 'preview' && (
+                <div className="pdf-preview-container" data-testid="pdf-preview-container">
+                  <object
+                    className="pdf-preview-frame"
+                    data={buildBinaryDataUrl(displayResponse?.body, 'application/pdf')}
+                    type="application/pdf"
+                    data-testid="pdf-preview-frame"
+                  >
+                    <div className="pdf-preview-fallback" data-testid="pdf-preview-fallback">
+                      <p>Your browser cannot display this PDF inline.</p>
+                      <a
+                        href={buildBinaryDataUrl(displayResponse?.body, 'application/pdf')}
+                        download="response.pdf"
+                      >
+                        Download PDF
+                      </a>
+                    </div>
+                  </object>
+                </div>
+              )}
+              {pdfViewMode === 'raw' && (
+                <pre className="binary-raw-view" data-testid="pdf-raw-body">{displayResponse?.body}</pre>
+              )}
+              {pdfViewMode === 'hex' && (
+                <HexView
+                  body={displayResponse?.body}
+                  showAll={hexShowAll}
+                  onShowAll={() => setHexShowAll(true)}
+                  testId="pdf-hex-body"
+                />
+              )}
+            </>
           ) : isJsonBody ? (
             <div className="json-view-wrapper">
               <JsonView

--- a/src/styles/response-viewer.css
+++ b/src/styles/response-viewer.css
@@ -227,6 +227,89 @@
   border-radius: var(--radius-sm);
 }
 
+/* PDF Preview */
+.pdf-preview-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.pdf-preview-frame {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg-tertiary);
+}
+
+.pdf-preview-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  color: var(--text-secondary);
+  text-align: center;
+  width: 100%;
+}
+
+.pdf-preview-fallback a {
+  color: var(--accent-primary);
+  text-decoration: underline;
+}
+
+/* Binary (Image/PDF) View Toggle */
+.binary-view-toggle {
+  margin-bottom: var(--space-2);
+}
+
+.binary-raw-view,
+.binary-hex-view {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre;
+  overflow: auto;
+  padding: var(--space-3);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  margin: 0;
+  height: 100%;
+}
+
+.binary-raw-view {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.binary-hex-view-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.binary-hex-truncated {
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-secondary);
+  font-size: 12px;
+  border-top: 1px solid var(--border-primary);
+  background: var(--bg-tertiary);
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--accent-primary);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
+}
+
 /* Desktop Agent Banner (shown when local URL fails on web) */
 .desktop-agent-banner {
   display: flex;

--- a/src/styles/response-viewer.css
+++ b/src/styles/response-viewer.css
@@ -227,20 +227,22 @@
   border-radius: var(--radius-sm);
 }
 
-/* PDF Preview */
+/* PDF Preview — fills remaining flex space in the response-content column.
+   No fixed height: avoids creating an outer scrollbar; scrolling stays inside the PDF viewer. */
 .pdf-preview-container {
   display: flex;
   width: 100%;
-  height: 100%;
-  min-height: 400px;
+  flex: 1;
+  min-height: 0;
   background: var(--bg-secondary);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .pdf-preview-frame {
   flex: 1;
   width: 100%;
-  height: 100%;
+  min-height: 0;
   border: none;
   background: var(--bg-tertiary);
 }


### PR DESCRIPTION
Closes #25.

## Summary

### PDF response preview
\`Content-Type: application/pdf\` responses now render inline in the Response Viewer instead of dumping raw base64. Uses \`<object data=\"data:application/pdf;base64,...\">\` with a nested fallback containing a download link, so browsers without an inline PDF viewer (notably macOS WKWebView in the Tauri desktop app) still get a usable affordance — no JS feature detection needed.

The bytes are already base64 in all transport paths since v0.1.12 (Edge proxy, browser-direct, Tauri Rust). This PR is render-only.

### Preview / Raw / Hex toggle for image and PDF
Image and PDF previews gain a segmented \`[Preview | Raw | Hex]\` control that matches the existing HTML preview toggle's visual language.
- **Raw** — base64 body string in a monospace pane.
- **Hex** — classic \`addr | hex | ascii\` dump (16 bytes per row), capped at 1 MB with a \"Show all\" affordance to avoid freezing on large bodies.

Switching views is pure state — no re-fetch.

### Refactor
\`buildImageSrc(body, mimeType)\` renamed to \`buildBinaryDataUrl(body, mimeType)\` since both image and PDF branches now use it. Logic identical (data URL passthrough, SVG inline, base64 passthrough, raw-binary \`btoa\` fallback).

## Files
- New: \`src/components/BinaryViewToggle.jsx\` — segmented control reused for image + PDF
- Modified: \`src/components/ResponseViewer.jsx\` — PDF branch, view-mode state, \`HexView\` sub-component, \`decodeToBytes\` / \`buildHexDump\` helpers
- Modified: \`src/styles/response-viewer.css\` — \`.pdf-preview-*\`, \`.binary-view-toggle\`, \`.binary-raw-view\`, \`.binary-hex-view\`, \`.binary-hex-truncated\`, \`.link-button\`
- New: \`e2e/pdf-preview.spec.ts\` (2 scenarios)
- New: \`e2e/binary-toggle.spec.ts\` (5 scenarios)
- New: \`acceptance/pdf-response-preview.md\`, \`acceptance/binary-raw-hex-toggle.md\`

## Test plan
- [x] All 16 viewer specs pass: 2 PDF preview + 5 binary toggle + 2 image preview + 6 HTML preview + 1 setup. PDF hex test asserts the \`%PDF\` magic bytes (\`25 50 44 46\`) appear at offset 0.
- [x] Regression on 25 specs across cURL panel, sidebar search, collection auth, environments, collection variables, request editor, collection — all pass.
- [x] PDF inline render verified against \`https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf\` (W3C-hosted, no auth).
- [x] Image preview default mode is \`preview\` so the existing image-preview test continues to pass without modification.

## Known limitation
- macOS Tauri (WKWebView) does not natively render \`data:application/pdf\` inline. The \`<object>\` fallback content (\"Download PDF\" link) handles this automatically — no JS feature detection.