### PR TITLE
feat: tab right-click context menu with bulk close operations (#27)

### DIFF
--- a/acceptance/tab-context-menu.md
+++ b/acceptance/tab-context-menu.md
@@ -1,0 +1,280 @@
+# Acceptance Spec: Tab Context Menu
+
+## Problem
+Tabs can only be closed one at a time via the tab's × button. Users with many tabs open need bulk close operations.
+
+## Scope
+- `src/components/TabBar.jsx` — `onContextMenu` on `.open-tab`, menu popover, outside-click + Escape dismiss
+- `src/hooks/useRequestActions.js` — new `closeManyTabs(ids, options)` action + shared `computeNextActiveTabId` helper; existing `closeTab` updated to use it
+- `src/components/ConfirmModal.jsx` — optional `listItems` prop rendered as a `<ul>` under the message string
+- `src/App.css` — `.tab-context-menu` styles reusing the `.request-menu` pattern
+
+Out of scope:
+- Reorder / pin / duplicate tab operations
+- Keyboard shortcuts for these operations
+- Changing the × button behavior
+
+## Interface Contract
+
+### 1. Shared focus helper — `src/hooks/useRequestActions.js`
+
+```js
+// Given the tab list as it was BEFORE closing, the ids being closed, and the
+// current active tab id, return the id that should be active after the close.
+// Rule: if current active is not being closed, keep it. Otherwise focus the
+// nearest remaining tab to the right of the closed-active tab's original
+// position; fall back to the nearest remaining tab on the left. Return null
+// if no tabs remain.
+function computeNextActiveTabId(tabsBefore, closedIds, currentActiveId) {
+  const closedSet = closedIds instanceof Set ? closedIds : new Set(closedIds);
+  const remaining = tabsBefore.filter(t => !closedSet.has(t.id));
+  if (remaining.length === 0) return null;
+  if (currentActiveId && !closedSet.has(currentActiveId)) return currentActiveId;
+
+  // Active was closed — find where it was and scan right, then left.
+  const activeIndex = tabsBefore.findIndex(t => t.id === currentActiveId);
+  if (activeIndex < 0) return remaining[0].id;
+  for (let i = activeIndex + 1; i < tabsBefore.length; i++) {
+    if (!closedSet.has(tabsBefore[i].id)) return tabsBefore[i].id;
+  }
+  for (let i = activeIndex - 1; i >= 0; i--) {
+    if (!closedSet.has(tabsBefore[i].id)) return tabsBefore[i].id;
+  }
+  return remaining[0].id;
+}
+```
+
+Existing `closeTab` is refactored to call this helper instead of its current `newTabs[newTabs.length - 1]` rule. (× button behavior is preserved for non-active-tab closes; for active-tab closes, focus now moves to the *right neighbor* rather than the rightmost tab — this is the issue's stated desired behavior, applied consistently to both entry points.)
+
+### 2. New bulk action — `closeManyTabs`
+
+```js
+// ids: Iterable<string> of tab ids to close
+// opts:
+//   force?: boolean              — skip dirty prompt even if skipCloseConfirm is off
+//   confirmTitle?: string        — override prompt title
+const closeManyTabs = useCallback(async (ids, opts = {}) => {
+  const idSet = new Set(ids);
+  if (idSet.size === 0) return;
+
+  const tabsBefore = openTabs;
+  const closing = tabsBefore.filter(t => idSet.has(t.id));
+  const dirtyClosing = closing.filter(t => t.dirty);
+
+  // Single consolidated prompt for dirty tabs
+  if (!opts.force && !userConfig?.skipCloseConfirm && dirtyClosing.length > 0) {
+    const confirmed = await confirm({
+      title: opts.confirmTitle || 'Unsaved Changes',
+      message: `You have unsaved changes in ${dirtyClosing.length} tab${dirtyClosing.length === 1 ? '' : 's'}. Close anyway?`,
+      listItems: dirtyClosing.map(t => tabDisplayName(t)),
+      confirmText: 'Close',
+      cancelText: 'Cancel',
+      variant: 'danger',
+    });
+    if (!confirmed) return;
+  }
+
+  // Temp tabs inside the batch: same rule as the × button — close if empty
+  // (untouched request with name "New Request" and no url/body), otherwise
+  // leave them alone (the existing UnsavedChangesModal flow is per-tab and
+  // too intrusive for bulk ops; skip them silently in this version).
+  const finalIds = new Set(
+    closing
+      .filter(t => !t.isTemporary || isEmptyTempRequest(t))
+      .map(t => t.id)
+  );
+
+  // Compute next active BEFORE mutating state
+  const nextActive = computeNextActiveTabId(tabsBefore, finalIds, activeTabId);
+
+  setOpenTabs(prev => prev.filter(t => !finalIds.has(t.id)));
+  setActiveTabId(nextActive);
+
+  // Clean up per-tab state (preview, conflicted, deleted, originalRequests)
+  for (const id of finalIds) {
+    cleanupTabState(id);
+  }
+}, [openTabs, activeTabId, userConfig, confirm, setOpenTabs, setActiveTabId]);
+```
+
+`tabDisplayName(tab)` produces the visible tab label (e.g., "GET /api/users" for request, the workflow name for workflow, collection name for collection — reuse existing tab-label logic from TabBar). `isEmptyTempRequest(tab)` / `cleanupTabState(id)` already exist or are trivially extracted from the current `closeTab`.
+
+### 3. ConfirmModal — list support
+
+Add an optional `listItems?: string[]` prop. When provided:
+
+```jsx
+<p className="confirm-message">{message}</p>
+{listItems?.length > 0 && (
+  <ul className="confirm-list" data-testid="confirm-list">
+    {listItems.map((item, i) => (
+      <li key={i}>{item}</li>
+    ))}
+  </ul>
+)}
+```
+
+CSS:
+```css
+.confirm-list {
+  margin: var(--space-2) 0 0 0;
+  padding-left: var(--space-5);
+  max-height: 200px;
+  overflow-y: auto;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.confirm-list li {
+  padding: 2px 0;
+}
+```
+
+The 200px cap prevents the modal from growing unbounded when many tabs are dirty.
+
+### 4. TabBar context menu
+
+State (in `TabBar`):
+```js
+const [menuState, setMenuState] = useState(null);
+// menuState = null | { tabId: string, x: number, y: number }
+const menuRef = useRef(null);
+```
+
+`onContextMenu` on the tab element:
+```jsx
+<div
+  className={`open-tab ...`}
+  onContextMenu={(e) => {
+    e.preventDefault();
+    setMenuState({ tabId: tab.id, x: e.clientX, y: e.clientY });
+  }}
+  ...
+>
+```
+
+Outside-click + Escape dismiss (useEffect wired on `menuState`).
+
+Menu render (sibling of the tab strip, not child):
+```jsx
+{menuState && (() => {
+  const clickedId = menuState.tabId;
+  const clickedIndex = openTabs.findIndex(t => t.id === clickedId);
+  if (clickedIndex < 0) return null;
+  const others = openTabs.filter(t => t.id !== clickedId);
+  const leftTabs = openTabs.slice(0, clickedIndex);
+  const rightTabs = openTabs.slice(clickedIndex + 1);
+  const unmodifiedOthers = others.filter(t => !t.dirty);
+
+  const showOthers = others.length > 0;
+  const showUnmodified = unmodifiedOthers.length > 0;
+  const showLeft = leftTabs.length > 0;
+  const showRight = rightTabs.length > 0;
+
+  return (
+    <div
+      ref={menuRef}
+      className="request-menu tab-context-menu"
+      style={{ position: 'fixed', top: menuState.y, left: menuState.x, right: 'auto' }}
+      data-testid="tab-context-menu"
+      role="menu"
+    >
+      <button className="request-menu-item" data-testid="tab-menu-close" onClick={() => { handleMenuClose(); closeSingleTab(clickedId); }}>Close</button>
+      {(showOthers || showUnmodified || showLeft || showRight) && <div className="request-menu-divider" />}
+      {showOthers && (
+        <button className="request-menu-item" data-testid="tab-menu-close-others" onClick={() => { handleMenuClose(); closeManyTabs(others.map(t => t.id), { confirmTitle: 'Close Other Tabs' }); }}>Close Other Tabs</button>
+      )}
+      {showUnmodified && (
+        <button className="request-menu-item" data-testid="tab-menu-close-unmodified" onClick={() => { handleMenuClose(); closeManyTabs(unmodifiedOthers.map(t => t.id), { force: true }); }}>Close Unmodified Tabs</button>
+      )}
+      {showLeft && (
+        <button className="request-menu-item" data-testid="tab-menu-close-left" onClick={() => { handleMenuClose(); closeManyTabs(leftTabs.map(t => t.id)); }}>Close Tabs to the Left</button>
+      )}
+      {showRight && (
+        <button className="request-menu-item" data-testid="tab-menu-close-right" onClick={() => { handleMenuClose(); closeManyTabs(rightTabs.map(t => t.id)); }}>Close Tabs to the Right</button>
+      )}
+    </div>
+  );
+})()}
+```
+
+`closeSingleTab(id)` uses the existing `closeTab` path so the single-close dirty prompt stays the same per-tab confirm (matches × button). The bulk ops use `closeManyTabs` (consolidated prompt).
+
+Position correction — after render, if the menu's right edge would exceed `window.innerWidth - 8`, shift `left` inward. Same for bottom edge. Use a `useLayoutEffect` on the menu element.
+
+### 5. CSS additions — `src/App.css`
+
+```css
+.tab-context-menu {
+  min-width: 180px;
+}
+.request-menu-divider {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--border-primary);
+}
+```
+
+Reuses `.request-menu` styling as-is. The class combination `request-menu tab-context-menu` gets the base drop + divider styling.
+
+## Acceptance Criteria
+
+### AC1 — Right-click opens menu
+Right-clicking any `.open-tab` opens `[data-testid="tab-context-menu"]` at the cursor position. Preventing default browser menu.
+
+### AC2 — Escape closes menu
+Pressing Escape while the menu is open dismisses it.
+
+### AC3 — Outside click closes menu
+Clicking anywhere outside the menu (including on another tab) dismisses it.
+
+### AC4 — Close item
+Clicking `[data-testid="tab-menu-close"]` closes the clicked tab. If the clicked tab was active, focus moves to the tab immediately to its right; if there is no right neighbor, focus moves to the left neighbor. This rule applies even when the clicked tab isn't active: the active tab is preserved if still present.
+
+### AC5 — Close Other Tabs
+Keeps only the clicked tab. If any of the closed tabs were dirty and `skipCloseConfirm` is false, shows a consolidated confirm prompt listing those dirty tabs by name. Cancel aborts the whole operation; no tabs close. Hidden when `openTabs.length === 1`.
+
+### AC6 — Close Unmodified Tabs
+Closes every tab that is NOT dirty and is NOT the clicked tab. Clicked tab stays regardless of its own dirty state. Other dirty tabs stay. No confirm prompt ever (nothing dirty is being closed). Hidden when there are no other clean tabs.
+
+### AC7 — Close Tabs to the Left
+Closes every tab positioned left of the clicked tab in `openTabs`. Same dirty-prompt rules as AC5. Hidden when clicked tab is index 0.
+
+### AC8 — Close Tabs to the Right
+Closes every tab positioned right of the clicked tab. Same dirty-prompt rules as AC5. Hidden when clicked tab is the last index.
+
+### AC9 — Dirty consolidated prompt
+When a bulk op would close N dirty tabs (N ≥ 1), the ConfirmModal opens with:
+- Title: `Unsaved Changes` (or the op's `confirmTitle` override for Close Other Tabs)
+- Message: `You have unsaved changes in N tab(s). Close anyway?`
+- A visible `[data-testid="confirm-list"]` `<ul>` listing each dirty tab's display name
+- Cancel aborts the whole bulk op.
+
+### AC10 — skipCloseConfirm bypass
+If `userConfig.skipCloseConfirm` is true, all bulk ops close immediately without any prompt. Matches the × button behavior.
+
+### AC11 — Menu does not clip off-screen
+On a right-click near the viewport's right or bottom edge, the menu repositions so it stays fully visible (within an 8px safety margin).
+
+### AC12 — Regression — × button unchanged
+Clicking the × button continues to work as before: per-tab dirty prompt via ConfirmModal, temp-tab flow unchanged, activation rule reuses the new `computeNextActiveTabId` (right-neighbor-first). Existing × behavior tests still pass.
+
+### AC13 — Regression — all existing ConfirmModal callers unchanged
+ConfirmModal without `listItems` renders exactly as before (no empty `<ul>`, no layout shift). Grep all `confirm({...})` callers — none specify `listItems`.
+
+## Test Plan
+
+### E2E — `e2e/tab-context-menu.spec.ts` (new file)
+
+1. **tab-menu-opens-on-right-click** — Open 3 requests in tabs. Right-click the middle tab. Assert `[data-testid="tab-context-menu"]` visible. Press Escape. Assert menu gone.
+2. **tab-menu-close** — From a 3-tab setup with the rightmost active, right-click the active tab, click `[data-testid="tab-menu-close"]`. Assert 2 tabs remain and the tab previously to the left of the closed one is now active.
+3. **tab-menu-close-others** — Open 3 tabs. Right-click the middle. Click `tab-menu-close-others`. Assert only the middle tab remains.
+4. **tab-menu-close-others-hidden-for-single-tab** — With only 1 tab open, right-click it. Assert `tab-menu-close-others` NOT visible.
+5. **tab-menu-close-left-right** — Open 3 tabs. Right-click the middle. Verify both `tab-menu-close-left` and `tab-menu-close-right` visible. Click `close-left`; assert 2 rightmost remain. Re-open 3 tabs, click `close-right`; assert 2 leftmost remain.
+6. **tab-menu-close-left-hidden-for-leftmost** — Right-click leftmost tab. Assert `tab-menu-close-left` NOT visible. Same for right on rightmost.
+7. **tab-menu-close-unmodified-keeps-dirty** — Open 3 tabs, modify the middle one (edit request URL) so it becomes dirty. Right-click the leftmost (clean) tab. Click `tab-menu-close-unmodified`. Assert the leftmost + middle (dirty) remain; the rightmost (clean) is gone.
+8. **tab-menu-close-unmodified-hidden-when-no-clean-others** — Open 2 tabs, modify the non-clicked one so both-but-clicked are dirty... actually set it up so every non-clicked tab is dirty → clicked is clean. Verify `tab-menu-close-unmodified` is hidden.
+9. **tab-menu-bulk-dirty-confirm** — Open 3 tabs, make 2 of them dirty. Right-click the clean tab, click `close-others`. Assert confirm modal opens with `[data-testid="confirm-list"]` showing both dirty tab names. Cancel → all 3 tabs still open. Re-do and Confirm → only the clicked tab remains.
+
+### Regression
+- `e2e/request.spec.ts` — × button flow still works (request-delete test).
+- Any existing confirm-modal-based test — must still pass with the new optional `listItems` prop.

--- a/e2e/tab-context-menu.spec.ts
+++ b/e2e/tab-context-menu.spec.ts
@@ -1,0 +1,328 @@
+import { test, expect, Page } from '@playwright/test';
+import { cleanupTestCollections } from './helpers/cleanup';
+
+// Generate unique names for each test run
+const timestamp = Date.now();
+const uniqueName = (base: string) => `${base} ${timestamp}`;
+
+test.afterAll(async () => { await cleanupTestCollections(timestamp); });
+
+/** Create a collection via sidebar and return its header locator */
+async function createCollection(page: Page, name: string) {
+  const addBtn = page.locator('.sidebar-toolbar .btn-icon').last();
+  await expect(addBtn).toBeEnabled({ timeout: 10000 });
+  await addBtn.click();
+  const modal = page.locator('.prompt-modal');
+  await expect(modal).toBeVisible({ timeout: 5000 });
+  await modal.locator('.prompt-input').fill(name);
+  await modal.locator('.prompt-btn-confirm').click();
+  await expect(modal).not.toBeVisible();
+  const header = page.locator('.collection-header').filter({ hasText: name });
+  await expect(header).toBeVisible({ timeout: 5000 });
+  return header;
+}
+
+/** Add a request to a collection via its context menu */
+async function addRequest(page: Page, collectionHeader: ReturnType<Page['locator']>) {
+  await collectionHeader.hover();
+  await collectionHeader.locator('.btn-menu').click();
+  const menu = page.locator('.collection-menu');
+  await expect(menu).toBeVisible();
+  await menu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+  await page.waitForTimeout(400);
+}
+
+/** Rename a request in the sidebar via its item context menu */
+async function renameRequestViaMenu(page: Page, requestItem: ReturnType<Page['locator']>, newName: string) {
+  await requestItem.hover();
+  await requestItem.locator('.btn-menu').click();
+  const menu = page.locator('.request-menu').last();
+  await expect(menu).toBeVisible();
+  await menu.locator('.request-menu-item').filter({ hasText: 'Rename' }).click();
+  const input = requestItem.locator('.rename-input');
+  await expect(input).toBeVisible();
+  await input.fill(newName);
+  await input.press('Enter');
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Open `count` request tabs with distinct names inside a fresh collection.
+ * Returns the created collection name and the ordered list of request names.
+ * Tabs end up in the same order in the tab bar (leftmost = names[0]).
+ */
+async function openRequestsInTabs(page: Page, collectionBase: string, count: number) {
+  const collectionName = uniqueName(collectionBase);
+  const header = await createCollection(page, collectionName);
+
+  const collection = page.locator('.collection').filter({
+    has: page.locator('.collection-header').filter({ hasText: collectionName }),
+  });
+
+  // Create `count` requests
+  for (let i = 0; i < count; i++) {
+    await addRequest(page, header);
+  }
+
+  const requests = collection.locator('.request-item');
+  await expect(requests).toHaveCount(count, { timeout: 5000 });
+
+  // Rename each to a stable, unique name
+  const names: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const nm = `Tab-${String.fromCharCode(65 + i)}-${timestamp}`;
+    names.push(nm);
+    await renameRequestViaMenu(page, requests.nth(i), nm);
+  }
+
+  // Click each request (left-to-right) to open tabs in that order.
+  // Single-clicking a request opens it as a *preview* tab which the next click
+  // would replace. Promote each preview to a persistent tab by typing into the
+  // URL (making it dirty) then reverting (clean again) — that clears
+  // previewTabId without leaving residual dirty state.
+  for (const nm of names) {
+    const item = collection.locator('.request-item').filter({ hasText: nm });
+    await item.click();
+    const tab = page.locator('.open-tab').filter({ hasText: nm });
+    await expect(tab).toBeVisible({ timeout: 5000 });
+    const urlInput = page.locator('.url-input');
+    await expect(urlInput).toBeVisible({ timeout: 5000 });
+    // Promote: fill a value (dirty → preview cleared), then revert (clean again).
+    await urlInput.fill('x');
+    await expect(tab).not.toHaveClass(/\bpreview\b/, { timeout: 5000 });
+    await urlInput.fill('');
+    // Wait for the tab to be clean again (dirty class removed).
+    await expect(tab).not.toHaveClass(/\bdirty\b/, { timeout: 5000 });
+  }
+
+  // Confirm tab count
+  await expect(page.locator('.open-tab')).toHaveCount(count, { timeout: 5000 });
+
+  return { collectionName, names };
+}
+
+/** Make the currently active tab dirty by typing into its URL input */
+async function makeTabDirty(page: Page, name: string) {
+  // Click the tab to make it active
+  const tab = page.locator('.open-tab').filter({ hasText: name });
+  await tab.click();
+  await expect(tab).toHaveClass(/active/);
+  // Wait for the editor to catch up
+  await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+  const urlInput = page.locator('.url-input');
+  await urlInput.click();
+  await urlInput.fill(`https://example.com/${name}`);
+  // Dirty indicator should appear on the tab
+  await expect(tab.locator('.tab-dirty')).toBeVisible({ timeout: 5000 });
+}
+
+/** Right-click a tab by visible name */
+async function rightClickTab(page: Page, name: string) {
+  const tab = page.locator('.open-tab').filter({ hasText: name });
+  await tab.click({ button: 'right' });
+  await expect(page.locator('[data-testid="tab-context-menu"]')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Tab Context Menu', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+    await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+    await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test('tab-menu-opens-on-right-click', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Open Menu', 3);
+
+    // Right-click the middle tab
+    await rightClickTab(page, names[1]);
+
+    const menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu).toBeVisible();
+
+    // Escape dismisses
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('tab-menu-close', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Close', 3);
+
+    // Activate the rightmost tab
+    const rightTab = page.locator('.open-tab').filter({ hasText: names[2] });
+    await rightTab.click();
+    await expect(rightTab).toHaveClass(/active/);
+
+    // Right-click the active (rightmost) tab and close it
+    await rightClickTab(page, names[2]);
+    await page.locator('[data-testid="tab-menu-close"]').click();
+
+    // 2 tabs remain
+    await expect(page.locator('.open-tab')).toHaveCount(2, { timeout: 5000 });
+
+    // Rightmost tab is gone
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).not.toBeVisible();
+
+    // Since the active tab was closed and there is no right neighbor,
+    // focus should fall back to the left neighbor (names[1] — the middle tab).
+    const middleTab = page.locator('.open-tab').filter({ hasText: names[1] });
+    await expect(middleTab).toHaveClass(/active/, { timeout: 5000 });
+  });
+
+  test('tab-menu-close-others', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Close Others', 3);
+
+    await rightClickTab(page, names[1]);
+    await page.locator('[data-testid="tab-menu-close-others"]').click();
+
+    // Only the middle tab remains
+    await expect(page.locator('.open-tab')).toHaveCount(1, { timeout: 5000 });
+    await expect(page.locator('.open-tab').filter({ hasText: names[1] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[0] })).not.toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).not.toBeVisible();
+  });
+
+  test('tab-menu-close-others-hidden-for-single-tab', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Single Tab', 1);
+
+    await rightClickTab(page, names[0]);
+
+    const menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu).toBeVisible();
+    await expect(menu.locator('[data-testid="tab-menu-close-others"]')).toHaveCount(0);
+  });
+
+  test('tab-menu-close-left', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM CloseLeft', 3);
+
+    await rightClickTab(page, names[1]);
+
+    const menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu.locator('[data-testid="tab-menu-close-left"]')).toBeVisible();
+    await expect(menu.locator('[data-testid="tab-menu-close-right"]')).toBeVisible();
+
+    await menu.locator('[data-testid="tab-menu-close-left"]').click();
+
+    // 2 rightmost remain (middle + right)
+    await expect(page.locator('.open-tab').filter({ hasText: names[0] })).not.toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[1] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).toBeVisible();
+  });
+
+  test('tab-menu-close-right', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM CloseRight', 3);
+
+    await rightClickTab(page, names[1]);
+    await page.locator('[data-testid="tab-menu-close-right"]').click();
+
+    // 2 leftmost remain (left + middle)
+    await expect(page.locator('.open-tab').filter({ hasText: names[0] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[1] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).not.toBeVisible();
+  });
+
+  test('tab-menu-close-left-hidden-for-leftmost', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Edge Tabs', 3);
+
+    // Leftmost — close-left should be hidden
+    await rightClickTab(page, names[0]);
+    let menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu).toBeVisible();
+    await expect(menu.locator('[data-testid="tab-menu-close-left"]')).toHaveCount(0);
+    // close-right still available (there are tabs on the right)
+    await expect(menu.locator('[data-testid="tab-menu-close-right"]')).toBeVisible();
+
+    // Dismiss
+    await page.keyboard.press('Escape');
+    await expect(menu).not.toBeVisible({ timeout: 5000 });
+
+    // Rightmost — close-right should be hidden
+    await rightClickTab(page, names[2]);
+    menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu).toBeVisible();
+    await expect(menu.locator('[data-testid="tab-menu-close-right"]')).toHaveCount(0);
+    await expect(menu.locator('[data-testid="tab-menu-close-left"]')).toBeVisible();
+  });
+
+  test('tab-menu-close-unmodified-keeps-dirty', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Unmodified', 3);
+
+    // Make the middle tab dirty
+    await makeTabDirty(page, names[1]);
+
+    // Right-click the leftmost (clean) tab
+    await rightClickTab(page, names[0]);
+
+    const menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu.locator('[data-testid="tab-menu-close-unmodified"]')).toBeVisible();
+    await menu.locator('[data-testid="tab-menu-close-unmodified"]').click();
+
+    // Leftmost (clicked) and middle (dirty) remain; rightmost (clean) gone
+    await expect(page.locator('.open-tab')).toHaveCount(2, { timeout: 5000 });
+    await expect(page.locator('.open-tab').filter({ hasText: names[0] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[1] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).not.toBeVisible();
+  });
+
+  test('tab-menu-close-unmodified-hidden-when-no-clean-others', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM NoClean', 3);
+
+    // Make every non-clicked tab dirty (we will click names[0]).
+    await makeTabDirty(page, names[1]);
+    await makeTabDirty(page, names[2]);
+
+    // The clicked tab (names[0]) is clean; all others are dirty.
+    await rightClickTab(page, names[0]);
+
+    const menu = page.locator('[data-testid="tab-context-menu"]');
+    await expect(menu).toBeVisible();
+    await expect(menu.locator('[data-testid="tab-menu-close-unmodified"]')).toHaveCount(0);
+  });
+
+  test('tab-menu-bulk-dirty-confirm', async ({ page }) => {
+    const { names } = await openRequestsInTabs(page, 'TCM Bulk Dirty', 3);
+
+    // Make names[0] and names[2] dirty; names[1] stays clean.
+    await makeTabDirty(page, names[0]);
+    await makeTabDirty(page, names[2]);
+
+    // Right-click the clean tab, click Close Others
+    await rightClickTab(page, names[1]);
+    await page.locator('[data-testid="tab-menu-close-others"]').click();
+
+    // Confirm modal appears listing the 2 dirty tab names
+    const confirmModal = page.locator('.confirm-modal');
+    await expect(confirmModal).toBeVisible({ timeout: 5000 });
+
+    const list = confirmModal.locator('[data-testid="confirm-list"]');
+    await expect(list).toBeVisible();
+    await expect(list).toContainText(names[0]);
+    await expect(list).toContainText(names[2]);
+    // Clean tab not listed
+    await expect(list).not.toContainText(names[1]);
+
+    // Cancel → all 3 tabs still open
+    await confirmModal.locator('.confirm-btn-cancel').click();
+    await expect(confirmModal).not.toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.open-tab')).toHaveCount(3, { timeout: 5000 });
+    await expect(page.locator('.open-tab').filter({ hasText: names[0] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[1] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).toBeVisible();
+
+    // Re-do: right-click the clean tab, Close Others, Confirm
+    await rightClickTab(page, names[1]);
+    await page.locator('[data-testid="tab-menu-close-others"]').click();
+    const confirmModal2 = page.locator('.confirm-modal');
+    await expect(confirmModal2).toBeVisible({ timeout: 5000 });
+    await confirmModal2.locator('.confirm-btn-confirm').click();
+    await expect(confirmModal2).not.toBeVisible({ timeout: 5000 });
+
+    // Only the clicked (clean) tab remains
+    await expect(page.locator('.open-tab')).toHaveCount(1, { timeout: 5000 });
+    await expect(page.locator('.open-tab').filter({ hasText: names[1] })).toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[0] })).not.toBeVisible();
+    await expect(page.locator('.open-tab').filter({ hasText: names[2] })).not.toBeVisible();
+  });
+});

--- a/src/App.css
+++ b/src/App.css
@@ -2017,6 +2017,11 @@ body {
   margin: 4px 6px;
 }
 
+/* Tab Context Menu */
+.tab-context-menu {
+  min-width: 180px;
+}
+
 /* Example Actions in Sidebar */
 .example-actions {
   position: relative;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -159,6 +159,7 @@ function AppContent() {
     loadEnvironments,
     loading,
     closeTab,
+    closeManyTabs,
     handleCreateCollection,
     handleCreateSubCollection,
     handleCreateRequest,
@@ -465,6 +466,7 @@ function AppContent() {
             conflictedTabs={conflictedTabs}
             deletedTabs={deletedTabs}
             closeTab={closeTab}
+            closeManyTabs={closeManyTabs}
             canEdit={canEdit}
             activeWorkspace={activeWorkspace}
             userConfig={userConfig}

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -28,6 +28,7 @@ export function ConfirmProvider({ children }) {
     confirmText = 'Confirm',
     cancelText = 'Cancel',
     variant = 'default',
+    listItems,
   }) => {
     return new Promise((resolve) => {
       setState({
@@ -37,6 +38,7 @@ export function ConfirmProvider({ children }) {
         confirmText,
         cancelText,
         variant,
+        listItems,
         resolve,
       });
     });
@@ -62,6 +64,7 @@ export function ConfirmProvider({ children }) {
           confirmText={state.confirmText}
           cancelText={state.cancelText}
           variant={state.variant}
+          listItems={state.listItems}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
         />
@@ -76,6 +79,7 @@ function ConfirmModal({
   confirmText,
   cancelText,
   variant,
+  listItems,
   onConfirm,
   onCancel,
 }) {
@@ -112,6 +116,13 @@ function ConfirmModal({
 
         <div className="confirm-body">
           <p className="confirm-message">{message}</p>
+          {Array.isArray(listItems) && listItems.length > 0 && (
+            <ul className="confirm-list" data-testid="confirm-list">
+              {listItems.map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ul>
+          )}
         </div>
 
         <div className="confirm-footer">

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { Terminal, Plus, Folder, FolderOpen, Play, FileText } from 'lucide-react';
 import { METHOD_COLORS } from '../constants/methodColors';
 
@@ -11,6 +11,7 @@ export function TabBar({
   conflictedTabs,
   deletedTabs,
   closeTab,
+  closeManyTabs,
   canEdit,
   activeWorkspace,
   userConfig,
@@ -20,6 +21,10 @@ export function TabBar({
 }) {
   const [draggingTabId, setDraggingTabId] = useState(null);
   const [dragOverTabId, setDragOverTabId] = useState(null);
+  const [menuState, setMenuState] = useState(null);
+  const menuRef = useRef(null);
+
+  const closeMenu = useCallback(() => setMenuState(null), []);
 
   const handleTabDragStart = useCallback((e, tabId) => {
     setDraggingTabId(tabId);
@@ -55,6 +60,70 @@ export function TabBar({
     setDragOverTabId(null);
   }, [draggingTabId, setOpenTabs]);
 
+  // Dismiss context menu on outside click or Escape
+  useEffect(() => {
+    if (!menuState) return;
+    const handleClickOutside = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        closeMenu();
+      }
+    };
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') closeMenu();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuState, closeMenu]);
+
+  // Clamp menu to viewport so it never clips past the edges
+  useLayoutEffect(() => {
+    if (!menuState || !menuRef.current) return;
+    const el = menuRef.current;
+    const rect = el.getBoundingClientRect();
+    const margin = 8;
+    let { x, y } = menuState;
+    let needsUpdate = false;
+    if (rect.right > window.innerWidth - margin) {
+      x = Math.max(margin, window.innerWidth - margin - rect.width);
+      needsUpdate = true;
+    }
+    if (rect.bottom > window.innerHeight - margin) {
+      y = Math.max(margin, window.innerHeight - margin - rect.height);
+      needsUpdate = true;
+    }
+    if (needsUpdate && (x !== menuState.x || y !== menuState.y)) {
+      setMenuState((prev) => (prev ? { ...prev, x, y } : prev));
+    }
+  }, [menuState]);
+
+  const closeSingleTab = useCallback((tabId, e) => {
+    const tab = openTabs.find((t) => t.id === tabId);
+    if (!tab) return;
+    if (userConfig?.skipCloseConfirm) {
+      closeTab(tabId, e, { force: true });
+    } else if (tab.isTemporary) {
+      const r = tab.request || {};
+      const isEmpty = !r.url && !r.body && (!r.headers || r.headers.length === 0) && (!r.params || r.params.length === 0) && (!r.form_data || r.form_data.length === 0) && (!r.auth_token);
+      if (isEmpty) {
+        closeTab(tabId, e);
+      } else {
+        setTempCloseTabId(tabId);
+      }
+    } else if (tab.dirty) {
+      setDirtyCloseTabId(tabId);
+    } else {
+      closeTab(tabId, e);
+    }
+  }, [openTabs, userConfig, closeTab, setTempCloseTabId, setDirtyCloseTabId]);
+
+  const bulkCloseOpts = useCallback((extra = {}) => (
+    userConfig?.skipCloseConfirm ? { ...extra, force: true } : extra
+  ), [userConfig]);
+
   return (
     <div className="open-tabs-bar" onWheel={onWheel}>
       {openTabs.length === 0 ? (
@@ -79,6 +148,10 @@ export function TabBar({
               key={tab.id}
               className={`open-tab ${tab.id === activeTabId ? 'active' : ''} ${tab.isTemporary ? 'temporary' : ''} ${isExample ? 'example-tab' : ''} ${isCollection ? 'collection-tab' : ''} ${isWorkflow ? 'workflow-tab' : ''} ${isDocs ? 'docs-tab' : ''} ${isConflicted ? 'conflicted' : ''} ${isDeleted ? 'deleted' : ''} ${draggingTabId === tab.id ? 'dragging' : ''} ${dragOverTabId === tab.id ? 'drag-over' : ''} ${previewTabId === tab.id ? 'preview' : ''}`}
               onClick={() => setActiveTabId(tab.id)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setMenuState({ tabId: tab.id, x: e.clientX, y: e.clientY });
+              }}
               draggable
               onDragStart={(e) => handleTabDragStart(e, tab.id)}
               onDragEnd={handleTabDragEnd}
@@ -113,21 +186,7 @@ export function TabBar({
                 className="tab-close"
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (userConfig.skipCloseConfirm) {
-                    closeTab(tab.id, e, { force: true });
-                  } else if (tab.isTemporary) {
-                    const r = tab.request || {};
-                    const isEmpty = !r.url && !r.body && (!r.headers || r.headers.length === 0) && (!r.params || r.params.length === 0) && (!r.form_data || r.form_data.length === 0) && (!r.auth_token);
-                    if (isEmpty) {
-                      closeTab(tab.id, e);
-                    } else {
-                      setTempCloseTabId(tab.id);
-                    }
-                  } else if (tab.dirty) {
-                    setDirtyCloseTabId(tab.id);
-                  } else {
-                    closeTab(tab.id, e);
-                  }
+                  closeSingleTab(tab.id, e);
                 }}
                 title="Close"
               >
@@ -174,6 +233,96 @@ export function TabBar({
           <Plus size={14} />
         </button>
       )}
+      {menuState && (() => {
+        const clickedId = menuState.tabId;
+        const clickedIndex = openTabs.findIndex((t) => t.id === clickedId);
+        if (clickedIndex < 0) return null;
+        const others = openTabs.filter((t) => t.id !== clickedId);
+        const leftTabs = openTabs.slice(0, clickedIndex);
+        const rightTabs = openTabs.slice(clickedIndex + 1);
+        const unmodifiedOthers = others.filter((t) => !t.dirty);
+
+        const showOthers = others.length > 0;
+        const showUnmodified = unmodifiedOthers.length > 0;
+        const showLeft = leftTabs.length > 0;
+        const showRight = rightTabs.length > 0;
+        const showAnyBulk = showOthers || showUnmodified || showLeft || showRight;
+
+        return (
+          <div
+            ref={menuRef}
+            className="request-menu tab-context-menu"
+            style={{ position: 'fixed', top: menuState.y, left: menuState.x, right: 'auto' }}
+            data-testid="tab-context-menu"
+            role="menu"
+          >
+            <button
+              className="request-menu-item"
+              data-testid="tab-menu-close"
+              onClick={(e) => {
+                e.stopPropagation();
+                closeMenu();
+                closeSingleTab(clickedId, e);
+              }}
+            >
+              Close
+            </button>
+            {showAnyBulk && <div className="request-menu-divider" />}
+            {showOthers && (
+              <button
+                className="request-menu-item"
+                data-testid="tab-menu-close-others"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeMenu();
+                  closeManyTabs(others.map((t) => t.id), bulkCloseOpts({ confirmTitle: 'Close Other Tabs' }));
+                }}
+              >
+                Close Other Tabs
+              </button>
+            )}
+            {showUnmodified && (
+              <button
+                className="request-menu-item"
+                data-testid="tab-menu-close-unmodified"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeMenu();
+                  closeManyTabs(unmodifiedOthers.map((t) => t.id), { force: true });
+                }}
+              >
+                Close Unmodified Tabs
+              </button>
+            )}
+            {showLeft && (
+              <button
+                className="request-menu-item"
+                data-testid="tab-menu-close-left"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeMenu();
+                  closeManyTabs(leftTabs.map((t) => t.id), bulkCloseOpts());
+                }}
+              >
+                Close Tabs to the Left
+              </button>
+            )}
+            {showRight && (
+              <button
+                className="request-menu-item"
+                data-testid="tab-menu-close-right"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeMenu();
+                  closeManyTabs(rightTabs.map((t) => t.id), bulkCloseOpts());
+                }}
+              >
+                Close Tabs to the Right
+              </button>
+            )}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/src/contexts/WorkbenchContext.jsx
+++ b/src/contexts/WorkbenchContext.jsx
@@ -283,7 +283,7 @@ export function WorkbenchProvider({ children, prompt, confirm, toast }) {
   // --- Hook composition ---
 
   const {
-    openCollectionInTab, openRequestInTab, openExampleInTab, closeTab,
+    openCollectionInTab, openRequestInTab, openExampleInTab, closeTab, closeManyTabs,
     handleCreateCollection, handleCreateSubCollection, handleCreateRequest,
     handleDeleteCollection, handleDeleteRequest, handleDuplicateRequest,
     handleRenameCollection, handleRenameRequest,
@@ -456,7 +456,7 @@ export function WorkbenchProvider({ children, prompt, confirm, toast }) {
     collectionVariables,
     examples, setExamples, environments, activeEnvironment, setActiveEnvironment,
     loadCollections, loadEnvironments, loading,
-    openCollectionInTab, openRequestInTab, openExampleInTab, saveFunctionsRef, closeTab,
+    openCollectionInTab, openRequestInTab, openExampleInTab, saveFunctionsRef, closeTab, closeManyTabs,
     handleCreateCollection, handleCreateSubCollection, handleCreateRequest,
     handleDeleteCollection, handleDeleteRequest, handleDuplicateRequest,
     handleRenameCollection, handleRenameRequest,

--- a/src/hooks/useRequestActions.js
+++ b/src/hooks/useRequestActions.js
@@ -1,5 +1,28 @@
 import { useCallback } from 'react';
 import * as data from '../data/index.js';
+import { tabDisplayName, isEmptyTempRequest } from '../utils/tabLabel.js';
+
+// Given the tab list as it was BEFORE closing, the ids being closed, and the
+// current active tab id, return the id that should be active after the close.
+// If the current active tab isn't being closed, keep it. Otherwise focus the
+// nearest remaining tab to the right of the closed-active tab's original
+// position; fall back to the nearest remaining tab on the left. Returns null
+// if no tabs remain.
+export function computeNextActiveTabId(tabsBefore, closedIds, currentActiveId) {
+  const closedSet = closedIds instanceof Set ? closedIds : new Set(closedIds);
+  const remaining = tabsBefore.filter((t) => !closedSet.has(t.id));
+  if (remaining.length === 0) return null;
+  if (currentActiveId && !closedSet.has(currentActiveId)) return currentActiveId;
+  const activeIndex = tabsBefore.findIndex((t) => t.id === currentActiveId);
+  if (activeIndex < 0) return remaining[0].id;
+  for (let i = activeIndex + 1; i < tabsBefore.length; i++) {
+    if (!closedSet.has(tabsBefore[i].id)) return tabsBefore[i].id;
+  }
+  for (let i = activeIndex - 1; i >= 0; i--) {
+    if (!closedSet.has(tabsBefore[i].id)) return tabsBefore[i].id;
+  }
+  return remaining[0].id;
+}
 
 export function useRequestActions({
   prompt,
@@ -227,31 +250,7 @@ export function useRequestActions({
     setPreviewTabId(tabId);
   }, [openTabs, originalRequestsRef, previewTabId, setActiveTabId, setOpenTabs, setPreviewTabId]);
 
-  const closeTab = useCallback(async (id, e, { force = false } = {}) => {
-    if (e) e.stopPropagation();
-
-    const tab = openTabs.find((item) => item.id === id);
-    if (!force && tab?.dirty) {
-      const confirmed = await confirm({
-        title: 'Unsaved Changes',
-        message: 'You have unsaved changes. Are you sure you want to close this tab?',
-        confirmText: 'Close',
-        cancelText: 'Cancel',
-        variant: 'danger',
-      });
-      if (!confirmed) return;
-    }
-
-    setOpenTabs((prev) => {
-      const newTabs = prev.filter((item) => item.id !== id);
-      if (activeTabId === id && newTabs.length > 0) {
-        setActiveTabId(newTabs[newTabs.length - 1].id);
-      } else if (newTabs.length === 0) {
-        setActiveTabId(null);
-      }
-      return newTabs;
-    });
-
+  const cleanupTabState = useCallback((id) => {
     if (previewTabId === id) {
       setPreviewTabId(null);
     }
@@ -270,16 +269,92 @@ export function useRequestActions({
 
     delete originalRequestsRef.current[id];
   }, [
-    activeTabId,
-    confirm,
-    openTabs,
     originalRequestsRef,
     previewTabId,
-    setActiveTabId,
     setConflictedTabs,
     setDeletedTabs,
-    setOpenTabs,
     setPreviewTabId,
+  ]);
+
+  const closeTab = useCallback(async (id, e, { force = false } = {}) => {
+    if (e) e.stopPropagation();
+
+    const tab = openTabs.find((item) => item.id === id);
+    if (!force && tab?.dirty) {
+      const confirmed = await confirm({
+        title: 'Unsaved Changes',
+        message: 'You have unsaved changes. Are you sure you want to close this tab?',
+        confirmText: 'Close',
+        cancelText: 'Cancel',
+        variant: 'danger',
+      });
+      if (!confirmed) return;
+    }
+
+    setOpenTabs((prev) => {
+      const nextActive = computeNextActiveTabId(prev, new Set([id]), activeTabId);
+      if (activeTabId === id || nextActive === null) {
+        setActiveTabId(nextActive);
+      }
+      return prev.filter((item) => item.id !== id);
+    });
+
+    cleanupTabState(id);
+  }, [
+    activeTabId,
+    cleanupTabState,
+    confirm,
+    openTabs,
+    setActiveTabId,
+    setOpenTabs,
+  ]);
+
+  const closeManyTabs = useCallback(async (ids, opts = {}) => {
+    const idSet = new Set(ids);
+    if (idSet.size === 0) return;
+
+    const tabsBefore = openTabs;
+    const closing = tabsBefore.filter((t) => idSet.has(t.id));
+    if (closing.length === 0) return;
+
+    const dirtyClosing = closing.filter((t) => t.dirty);
+
+    if (!opts.force && dirtyClosing.length > 0) {
+      const confirmed = await confirm({
+        title: opts.confirmTitle || 'Unsaved Changes',
+        message: `You have unsaved changes in ${dirtyClosing.length} tab${dirtyClosing.length === 1 ? '' : 's'}. Close anyway?`,
+        listItems: dirtyClosing.map((t) => tabDisplayName(t)),
+        confirmText: 'Close',
+        cancelText: 'Cancel',
+        variant: 'danger',
+      });
+      if (!confirmed) return;
+    }
+
+    // Temp tabs: close only the empty "New Request" ones; leave user-modified
+    // temp tabs alone so we don't silently drop in-progress work.
+    const finalIds = new Set(
+      closing
+        .filter((t) => !t.isTemporary || isEmptyTempRequest(t))
+        .map((t) => t.id)
+    );
+    if (finalIds.size === 0) return;
+
+    const nextActive = computeNextActiveTabId(tabsBefore, finalIds, activeTabId);
+
+    setOpenTabs((prev) => prev.filter((t) => !finalIds.has(t.id)));
+    setActiveTabId(nextActive);
+
+    for (const id of finalIds) {
+      cleanupTabState(id);
+    }
+  }, [
+    activeTabId,
+    cleanupTabState,
+    confirm,
+    openTabs,
+    setActiveTabId,
+    setOpenTabs,
   ]);
 
   const handleCreateCollection = useCallback(async () => {
@@ -685,6 +760,7 @@ export function useRequestActions({
     openRequestInTab,
     openExampleInTab,
     closeTab,
+    closeManyTabs,
     handleCreateCollection,
     handleCreateSubCollection,
     handleCreateRequest,

--- a/src/styles/modals.css
+++ b/src/styles/modals.css
@@ -102,6 +102,19 @@
   margin: 0;
 }
 
+.confirm-list {
+  margin: var(--space-2) 0 0 0;
+  padding-left: var(--space-5);
+  max-height: 200px;
+  overflow-y: auto;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.confirm-list li {
+  padding: 2px 0;
+}
+
 .confirm-footer {
   display: flex;
   justify-content: flex-end;

--- a/src/utils/tabLabel.js
+++ b/src/utils/tabLabel.js
@@ -1,0 +1,35 @@
+// Derive a human-readable display name for a tab. Mirrors the label logic
+// used by TabBar's render so confirm prompts and other UIs show the same
+// name the user sees on the tab strip.
+export function tabDisplayName(tab) {
+  if (!tab) return 'Untitled';
+  const isExample = tab.type === 'example';
+  const isCollection = tab.type === 'collection';
+  const isWorkflow = tab.type === 'workflow';
+  const isDocs = tab.type === 'docs';
+  const name = isDocs
+    ? tab.docs?.collectionName
+    : isWorkflow
+      ? tab.workflow?.name
+      : isCollection
+        ? tab.collection?.name
+        : isExample
+          ? tab.example?.name
+          : tab.request?.name;
+  return name || 'Untitled';
+}
+
+// A temp tab counts as empty when it matches a freshly-created "New Request"
+// with no user input in url, body, headers, params, form_data, or auth_token.
+export function isEmptyTempRequest(tab) {
+  if (!tab?.isTemporary) return false;
+  const r = tab.request || {};
+  const nameIsDefault = !r.name || r.name === 'New Request';
+  const noUrl = !r.url;
+  const noBody = !r.body;
+  const noHeaders = !r.headers || r.headers.length === 0;
+  const noParams = !r.params || r.params.length === 0;
+  const noFormData = !r.form_data || r.form_data.length === 0;
+  const noAuth = !r.auth_token;
+  return nameIsDefault && noUrl && noBody && noHeaders && noParams && noFormData && noAuth;
+}


### PR DESCRIPTION
Closes #27.

## Summary
Right-clicking an open tab opens a context menu with:
- **Close** — closes the clicked tab; if it was active, focus moves to its right neighbor (fallback left). Same rule now applies to the × button via a shared `computeNextActiveTabId` helper.
- **Close Other Tabs** — keeps only the clicked tab.
- **Close Unmodified Tabs** — keeps the clicked tab + every dirty tab.
- **Close Tabs to the Left** — closes every tab to the left.
- **Close Tabs to the Right** — closes every tab to the right.

Items are hidden when they would do nothing (rightmost hides "Close Tabs to the Right", single-tab hides "Close Other Tabs", etc.).

## Dirty-tab handling
Bulk ops that include dirty tabs show a **single consolidated ConfirmModal** listing each affected tab by name. Cancel aborts the whole op. `userConfig.skipCloseConfirm` bypasses the prompt the same way it does for the × button.

`ConfirmModal` got a new optional `listItems?: string[]` prop. All five existing call sites pass nothing and render byte-identical output.

## Files
- New: `src/utils/tabLabel.js` (`tabDisplayName`, `isEmptyTempRequest`)
- New: `e2e/tab-context-menu.spec.ts` (10 scenarios)
- Modified: `src/components/TabBar.jsx` (context menu markup + state + viewport clamp + outside-click/Escape dismiss; reuses existing × button decision tree via `closeSingleTab`)
- Modified: `src/hooks/useRequestActions.js` (`computeNextActiveTabId`, refactored `closeTab`, new `closeManyTabs`)
- Modified: `src/components/ConfirmModal.jsx` (optional `listItems` → `<ul data-testid="confirm-list">`)
- Modified: `src/contexts/WorkbenchContext.jsx`, `src/App.jsx` (wire `closeManyTabs` through)
- Modified: `src/App.css`, `src/styles/modals.css`

## Test plan
- [x] 10 new E2E specs in `e2e/tab-context-menu.spec.ts` — all pass.
- [x] Regression: `request`, `collection`, `request-editor`, `example`, `collection-auth`, `environment`, `collection-variables` — 23/23 pass.
- [x] × button behavior unchanged (still uses per-tab dirty prompt + temp-tab flow).
- [x] Existing `confirm({...})` callers verified unaffected (no caller passes `listItems`).

## Behavior change worth flagging
The active-tab-close focus rule changed: previously focus moved to the rightmost remaining tab; now it moves to the right neighbor of the closed tab (or left if there's no right). This is the issue's stated desired behavior, applied consistently to both the new "Close" menu item and the existing × button so the UX is coherent.