### PR TITLE
feat: Postman import/export round-trip repair (part 1 of 3 for #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Improved
+
+- **Postman Import/Export Round-Trip** — Exporting a collection now preserves bearer auth, `Inherit from Parent` auth, folder/collection-level auth, pre/post scripts (request and collection level), and collection variables. Importing recognizes Postman's `event[]` script format and maps API Key auth (header location) into a request header. Basic, OAuth 1.0, OAuth 2.0, and unknown auth types no longer silently drop — they surface a per-request warning in a new "Import Warnings" modal. Part 1 of 3 for #30. (#30)
+
+### Breaking
+
+- **Postman collection-level `variable[]` now imports as collection variables.** Previously, importing a Postman file with top-level `variable[]` silently created a new Environment named `"<Collection> Variables"`. It now creates Post Umbrella collection variables on the imported root collection (matching the v0.1.8 collection-variables feature). Users who relied on the old behavior should recreate the environment manually or re-scope the values to collection variables. (#30)
+
 ## v0.1.12
 
 ### New

--- a/acceptance/import-roundtrip-repair.md
+++ b/acceptance/import-roundtrip-repair.md
@@ -1,0 +1,308 @@
+# Acceptance Spec: Postman Import/Export Round-Trip Repair (PR #1 of 3 for #30)
+
+## Problem
+Our Postman v2.1 export emits only method, URL, headers, body, and examples. It silently drops auth, pre/post scripts, collection variables, inherit semantics, and folder-level auth. Our import likewise drops script events, non-bearer auth types, and maps collection-level variables to a separate Environment rather than to collection variables. Round-tripping an exported file through the importer loses half the user's work with no warning.
+
+## Scope
+
+### In
+- `src/data/supabase/sync.js` — `buildPostmanRequest` + `buildPostmanCollection`
+- `src/data/supabase/collectionVars.js` or equivalent — export needs to read collection variables (create a helper if not exposed)
+- `supabase/functions/import-collection/index.ts` — `parseCollection` + field mappers + warnings accumulator
+- `src/hooks/useRequestActions.js` — `handleImport` consumes `warnings[]` from the response
+- `src/components/AppModals.jsx` (or wherever the import toast fires) — display warnings
+- `e2e/fixtures/imports/` (new) + a new E2E spec covering round-trip
+
+### Out
+- Format picker UI (PR #2)
+- Foreign templating detection / Insomnia tag handling (PR #2)
+- Workflows export/import (deferred)
+- OAuth2 handling (reject with warning, don't try to import)
+- OpenAPI (PR #3)
+- UI redesign — reuse the existing import modal, only the result toast changes
+
+## Interface Contract
+
+### 1. Export — `buildPostmanRequest(req, examples, parentAuth)`
+
+Signature adds `parentAuth` so the function can emit `auth: null` (Postman's inherit marker) only when the parent actually has an auth to inherit.
+
+```js
+function buildPostmanRequest(req, examples, parentAuth) {
+  const postman = {
+    name: req.name,
+    request: {
+      method: req.method,
+      header: (req.headers || []).map(h => ({
+        key: h.key,
+        value: h.value,
+        disabled: h.enabled === false,
+      })),
+      url: { raw: req.url, ...parseUrl(req.url) },
+    },
+    response: /* existing examples mapping */,
+  };
+
+  // Body — unchanged from current behavior
+  if (req.body && req.body_type !== 'none') {
+    postman.request.body = { ... };
+  }
+
+  // Auth
+  if (req.auth_type === 'bearer' && req.auth_token) {
+    postman.request.auth = {
+      type: 'bearer',
+      bearer: [{ key: 'token', value: req.auth_token, type: 'string' }],
+    };
+  } else if (req.auth_type === 'inherit') {
+    // Postman convention: omit `auth` entirely, or emit null. We emit nothing —
+    // omitting the field means "inherit" when a parent has auth.
+    // No-op here.
+  } else if (req.auth_type === 'none' && parentAuth) {
+    // User explicitly set "No Auth" on a request that has an auth ancestor.
+    // Postman represents this as { type: 'noauth' }.
+    postman.request.auth = { type: 'noauth' };
+  }
+
+  // Scripts — Postman event[] with listen: 'prerequest' | 'test'
+  const event = [];
+  if (req.pre_script) {
+    event.push({
+      listen: 'prerequest',
+      script: { type: 'text/javascript', exec: req.pre_script.split('\n') },
+    });
+  }
+  if (req.post_script) {
+    event.push({
+      listen: 'test',
+      script: { type: 'text/javascript', exec: req.post_script.split('\n') },
+    });
+  }
+  if (event.length > 0) postman.event = event;
+
+  return postman;
+}
+```
+
+### 2. Export — `buildPostmanCollection(collection, allCollections, allRequests, allExamples, allCollectionVariables, parentAuth)`
+
+Root collection also emits:
+- `auth` (same shape as request-level, when `collection.auth_type === 'bearer'`)
+- `event` (collection pre/post scripts, same shape)
+- `variable` (our collection_variables for the root, as `[{key, value, type: 'string'}]`)
+
+Nested folders:
+- `auth`, `event` passed through where present on the folder
+- `variable` NOT emitted on folders (our collection variables are root-scoped)
+
+Inheritance threading:
+- Pass an `effectiveAuth` down the recursion so child requests can decide whether to emit `auth: null` (inherit meaningful) vs skip (no parent auth exists).
+
+```js
+function buildPostmanCollection(collection, allCollections, allRequests, allExamples, allVariables, parentAuth = null) {
+  const myAuth = (collection.auth_type === 'bearer' && collection.auth_token)
+    ? { type: 'bearer', bearer: [{ key: 'token', value: collection.auth_token, type: 'string' }] }
+    : collection.auth_type === 'inherit' ? null /* inherit parent */ : undefined;
+  const effectiveAuth = myAuth === undefined ? parentAuth : (myAuth === null ? parentAuth : myAuth);
+
+  const collectionRequests = allRequests.filter(r => r.collection_id === collection.id);
+  const childCollections = allCollections.filter(c => c.parent_id === collection.id);
+
+  const items = [
+    ...collectionRequests.map(req => buildPostmanRequest(req, allExamples.filter(e => e.request_id === req.id), effectiveAuth)),
+    ...childCollections.map(child => {
+      // Recursive folder
+      const inner = buildPostmanCollection(child, allCollections, allRequests, allExamples, allVariables, effectiveAuth);
+      return {
+        name: child.name,
+        item: inner.item,
+        ...(inner.auth ? { auth: inner.auth } : {}),
+        ...(inner.event ? { event: inner.event } : {}),
+      };
+    }),
+  ];
+
+  const result = {
+    info: {
+      _postman_id: collection.id,
+      name: collection.name,
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    item: items,
+  };
+
+  if (myAuth && myAuth !== null) result.auth = myAuth;
+  const event = [];
+  if (collection.pre_script) event.push({ listen: 'prerequest', script: { type: 'text/javascript', exec: collection.pre_script.split('\n') } });
+  if (collection.post_script) event.push({ listen: 'test', script: { type: 'text/javascript', exec: collection.post_script.split('\n') } });
+  if (event.length > 0) result.event = event;
+
+  // Root-only: emit collection variables
+  if (!collection.parent_id && Array.isArray(allVariables) && allVariables.length > 0) {
+    result.variable = allVariables
+      .filter(v => v.enabled !== false && v.key)
+      .map(v => ({ key: v.key, value: v.value || v.initial_value || '', type: 'string' }));
+  }
+
+  return result;
+}
+```
+
+`exportCollection(id)` loads `allVariables` via a new helper (e.g., `getCollectionVariables(rootId)`) and passes it in. If the helper doesn't exist for this use case, add it inline — no new module required.
+
+### 3. Import — Edge Function `parseCollection`
+
+Recursion signature adds `parentHasAuth: boolean` and a `warnings: string[]` accumulator.
+
+Auth mapping:
+```ts
+function parseAuth(
+  auth: any,
+  parentHasAuth: boolean,
+  warnings: string[],
+  context: string
+): { auth_type: string; auth_token: string } {
+  if (!auth) {
+    // Undefined / null auth on an item whose parent has auth → inherit
+    return parentHasAuth
+      ? { auth_type: 'inherit', auth_token: '' }
+      : { auth_type: 'none', auth_token: '' };
+  }
+  if (auth.type === 'noauth') return { auth_type: 'none', auth_token: '' };
+  if (auth.type === 'bearer' && Array.isArray(auth.bearer)) {
+    const tokenItem = auth.bearer.find((b: any) => b.key === 'token');
+    return { auth_type: 'bearer', auth_token: tokenItem?.value || '' };
+  }
+  if (auth.type === 'apikey') {
+    // Map to a header (when in=header) or leave a warning for query-location key
+    warnings.push(`${context}: API Key auth is not natively supported — imported as a plain header. Manual review recommended.`);
+    // Best-effort: inject a header into the request (caller handles this; here we just return 'none')
+    return { auth_type: 'none', auth_token: '' };
+  }
+  if (auth.type === 'basic') {
+    warnings.push(`${context}: Basic auth is not supported yet — dropped.`);
+    return { auth_type: 'none', auth_token: '' };
+  }
+  if (auth.type === 'oauth2' || auth.type === 'oauth1') {
+    warnings.push(`${context}: OAuth auth is not supported — dropped. You'll need to configure auth manually.`);
+    return { auth_type: 'none', auth_token: '' };
+  }
+  warnings.push(`${context}: Unknown auth type "${auth.type}" — dropped.`);
+  return { auth_type: 'none', auth_token: '' };
+}
+```
+
+For API Key `in: header`, the parser should additionally inject the header into the request's header list rather than dropping it silently. Spec-level: if `auth.type === 'apikey'` and `auth.apikey.find(a => a.key === 'in').value === 'header'`, push a header `{ key: <keyName>, value: <keyValue>, enabled: true }` into the request's headers AND leave `auth_type = 'none'`. That way the request actually works post-import. Record a warning so the user knows what happened.
+
+Script mapping:
+```ts
+function parseEvents(event: any[] | undefined): { pre_script: string; post_script: string } {
+  if (!Array.isArray(event)) return { pre_script: '', post_script: '' };
+  let pre_script = '';
+  let post_script = '';
+  for (const ev of event) {
+    const code = Array.isArray(ev?.script?.exec) ? ev.script.exec.join('\n') : (ev?.script?.exec || '');
+    if (ev.listen === 'prerequest') pre_script = code;
+    else if (ev.listen === 'test') post_script = code;
+  }
+  return { pre_script, post_script };
+}
+```
+
+`parseCollection` applies this at both folder level (writes to the `collections` table's `pre_script` / `post_script` columns — add columns if missing; they exist since v0.1.8) and request level.
+
+Collection-level `variable`:
+- Currently creates a separate Environment. Change: when importing the ROOT collection, write variables to `collection_variables` (table exists since v0.1.8) keyed to the root collection id. Do NOT create an environment.
+- Schema: `{ collection_id: rootId, key, initial_value, enabled: true, sort_order: idx }`.
+- Warning emitted: `"Imported N collection variables into collection '<name>'."` (informational).
+- **Breaking change flag**: the old behavior created an environment. Call this out prominently in the PR description and CHANGELOG.
+
+### 4. Warning channel
+
+Edge Function response shape extends:
+```ts
+{
+  success: true,
+  rootCollectionId,
+  collectionsCount,
+  requestsCount,
+  environment: null,                   // No longer used (collection vars path)
+  warnings: string[],                  // NEW — user-facing messages
+}
+```
+
+Client `importCollection` returns the full response unchanged. `handleImport` in `useRequestActions.js`:
+```js
+const result = await data.importCollection(postmanData, workspaceId);
+if (result.warnings?.length > 0) {
+  toast.warning(`Imported with ${result.warnings.length} warning(s). Click for details.`, {
+    action: () => showImportWarningsModal(result.warnings),
+  });
+} else {
+  toast.success(`Imported "${rootCollection.name}"`);
+}
+```
+
+`showImportWarningsModal` can be a simple `ConfirmModal` invocation with `listItems` (the prop we added for the tab context menu PR #28). Title: `Import Warnings`. Confirm text: `OK`, no cancel.
+
+### 5. Params field
+Currently imported as `params: '[]'` verbatim. URLs already carry query strings; leave params empty — the URL is the source of truth. No change needed here; call it out so reviewers don't "fix" it.
+
+## Acceptance Criteria
+
+### AC1 — Bearer auth round-trips
+Given a request with `auth_type='bearer'` and `auth_token='abc'`, exporting produces `request.auth = { type: 'bearer', bearer: [{key:'token', value:'abc', type:'string'}] }`. Re-importing yields the same `auth_type` and `auth_token`.
+
+### AC2 — `auth_type='inherit'` round-trips
+Given a collection with `auth_type='bearer'` and a child request with `auth_type='inherit'`, export emits the collection's `auth` field AND omits `auth` on the request. Re-import sets the request's `auth_type` back to `'inherit'` because `parentHasAuth` is true.
+
+### AC3 — Pre/post scripts round-trip
+A request with `pre_script='console.log(1)'` and `post_script='pm.test(...)'` exports to `event: [{listen:'prerequest',...}, {listen:'test',...}]` with the exec array containing the script split by `\n`. Re-import restores the scripts byte-identically. Same at the collection/folder level.
+
+### AC4 — Collection variables round-trip to collection variables
+Root collection with 3 collection variables `{api_key, base_url, timeout}` exports as `variable: [{key,value,type:'string'}, ...]`. Re-import creates those as COLLECTION variables on the imported root collection. No new environment is created.
+
+### AC5 — API Key auth best-effort
+A Postman file with `auth: { type: 'apikey', apikey: [{key:'key',value:'X-API-Key'}, {key:'value',value:'secret'}, {key:'in',value:'header'}] }` imports as a request with `X-API-Key: secret` added to its header list AND `auth_type='none'`. A warning is emitted listing the mapping.
+
+### AC6 — Unsupported auth types are warned, not silently dropped
+`basic`, `oauth1`, `oauth2` each produce a warning like `"<request name>: Basic auth is not supported yet — dropped."` and `auth_type='none'`. NO silent drop.
+
+### AC7 — Warnings surface in UI
+Given an import with warnings, the user sees a toast saying `"Imported with N warning(s)."` that opens a modal listing each warning. Given an import with NO warnings, the toast is the standard success.
+
+### AC8 — No regression in existing behavior
+- Existing Postman collections (with just methods + URLs + headers + bodies) still import identically.
+- Duplicate collection name still rejects with the existing error message.
+- Partial-failure rollback still fires on request insert failure.
+- cURL import modal is unchanged.
+
+### AC9 — Round-trip E2E proves persistence
+A fixture Postman file covering auth (bearer, inherit, none), scripts, collection variables, and nested folders exports → reimports → diffing the persisted state shows no drift in the fields above.
+
+### AC10 — Breaking change documented
+The PR description + CHANGELOG entry prominently note: "Postman `variable[]` at the collection level now imports as collection variables (v0.1.8 feature) instead of a separate environment."
+
+## Test Plan
+
+### Unit-ish (Deno tests on the Edge Function)
+Not required for this PR if the project doesn't already test Edge Functions — verify by E2E.
+
+### E2E — new file `e2e/fixtures/imports/postman-v2.1-roundtrip.json`
+A hand-crafted Postman v2.1 file containing:
+- Root collection name: `RT Postman Test <timestamp>` (use a placeholder; actual timestamp injected by fixture helper)
+- Root collection with: bearer auth + pre_script + post_script + 2 collection variables
+- 3 nested folders (2 levels deep)
+- 5 requests with varied auth: bearer, inherit, noauth, apikey(header), basic
+- 1 request with pre/post scripts
+
+### E2E test — `e2e/import-roundtrip.spec.ts`
+1. **roundtrip-postman-v2.1** — load the fixture, import via the existing modal, open the created collection, assert: root has the 2 collection variables; a request in a nested folder shows `auth_type='bearer'` inherited from the root; a request with explicit bearer shows its token; a request with scripts has them populated. Then click the "Export" action, compare the exported JSON against the fixture — allow for UUID differences but assert structural equality on `auth`, `event`, `variable`, folder hierarchy.
+2. **import-warnings-surface** — import a fixture containing `auth: basic` and `auth: oauth2`. Assert a toast appears with "N warnings", click it, assert a modal with the warning strings opens.
+3. **import-apikey-header** — import a fixture with `auth.apikey` + `in: header`. Assert the resulting request has the header added AND a warning was emitted.
+
+### Regression (must still pass unchanged)
+- `e2e/import.spec.ts` (existing Postman import test)
+- Any existing cURL import test
+- `e2e/collection-auth.spec.ts` (auth inheritance continues to work post-import)
+- `e2e/collection-variables.spec.ts` (collection variables feature continues to work — just the import path changes its behavior, not the runtime feature)

--- a/e2e/fixtures/imports/postman-v2.1-roundtrip.json
+++ b/e2e/fixtures/imports/postman-v2.1-roundtrip.json
@@ -1,0 +1,143 @@
+{
+  "info": {
+    "_postman_id": "rt-postman-test-id",
+    "name": "RT Postman Test",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      { "key": "token", "value": "root-token", "type": "string" }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": ["console.log(\"root pre\")"]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": ["console.log(\"root post\")"]
+      }
+    }
+  ],
+  "variable": [
+    { "key": "api_key", "value": "abc123", "type": "string" },
+    { "key": "base_url", "value": "https://httpbin.org", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "Folder A",
+      "item": [
+        {
+          "name": "Bearer Request",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/bearer",
+              "host": ["{{base_url}}"],
+              "path": ["bearer"]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                { "key": "token", "value": "req-token", "type": "string" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "SubFolder",
+          "item": [
+            {
+              "name": "Inherit Request",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/get",
+                  "host": ["{{base_url}}"],
+                  "path": ["get"]
+                }
+              },
+              "response": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "NoAuth Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/get",
+          "host": ["{{base_url}}"],
+          "path": ["get"]
+        },
+        "auth": {
+          "type": "noauth"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "APIKey Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/headers",
+          "host": ["{{base_url}}"],
+          "path": ["headers"]
+        },
+        "auth": {
+          "type": "apikey",
+          "apikey": [
+            { "key": "key", "value": "X-API-Key" },
+            { "key": "value", "value": "secret123" },
+            { "key": "in", "value": "header" }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Scripted Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/get",
+          "host": ["{{base_url}}"],
+          "path": ["get"]
+        }
+      },
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": ["console.log(\"req pre\")"]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": ["console.log(\"req post\")"]
+          }
+        }
+      ],
+      "response": []
+    }
+  ]
+}

--- a/e2e/fixtures/imports/postman-v2.1-unsupported-auth.json
+++ b/e2e/fixtures/imports/postman-v2.1-unsupported-auth.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "_postman_id": "rt-postman-unsupported-auth-id",
+    "name": "RT Postman Unsupported Auth",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Basic Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://httpbin.org/basic-auth/u/p",
+          "protocol": "https",
+          "host": ["httpbin", "org"],
+          "path": ["basic-auth", "u", "p"]
+        },
+        "auth": {
+          "type": "basic",
+          "basic": [
+            { "key": "username", "value": "u" },
+            { "key": "password", "value": "p" }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "OAuth Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://httpbin.org/get",
+          "protocol": "https",
+          "host": ["httpbin", "org"],
+          "path": ["get"]
+        },
+        "auth": {
+          "type": "oauth2",
+          "oauth2": []
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/e2e/import-roundtrip.spec.ts
+++ b/e2e/import-roundtrip.spec.ts
@@ -1,0 +1,338 @@
+import { test, expect, Page } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { cleanupTestCollections } from './helpers/cleanup';
+
+// Generate unique names for each test run
+const timestamp = Date.now();
+const uniqueName = (base: string) => `${base} ${timestamp}`;
+
+test.afterAll(async () => { await cleanupTestCollections(timestamp); });
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, 'fixtures', 'imports');
+
+function loadFixture(fileName: string): any {
+  const raw = readFileSync(join(FIXTURES_DIR, fileName), 'utf-8');
+  return JSON.parse(raw);
+}
+
+async function waitForApp(page: Page) {
+  await page.goto('/');
+  await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 15000 });
+  await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+  await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
+  await expect(page.locator('.sidebar')).toBeVisible();
+  await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Open the import dropdown and choose "Collection File", then upload a Postman JSON file.
+ * Mirrors the pattern from `e2e/import.spec.ts`.
+ */
+async function importPostmanFile(page: Page, collectionJsonObj: any, fileName = 'test-collection.json') {
+  const importTrigger = page.locator('.import-dropdown-trigger');
+  await expect(importTrigger).toBeVisible();
+  await importTrigger.click();
+
+  const importMenu = page.locator('.import-dropdown-menu');
+  await expect(importMenu).toBeVisible();
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await importMenu.locator('.import-dropdown-item').filter({ hasText: 'Collection File' }).click();
+
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: fileName,
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify(collectionJsonObj)),
+  });
+}
+
+/**
+ * Expand a collection (root or nested folder) in the sidebar by clicking its arrow.
+ * If the arrow is already in the expanded state (ChevronDown), this clicks it again,
+ * so callers should call once when the node is collapsed.
+ */
+async function expandCollectionHeader(page: Page, headerLocator: ReturnType<Page['locator']>) {
+  const arrow = headerLocator.locator('.collection-arrow');
+  if (!(await arrow.isVisible().catch(() => false))) return;
+  // lucide-react renders ChevronDown when expanded, ChevronRight when collapsed.
+  const svgClass = (await arrow.locator('svg').getAttribute('class').catch(() => '')) || '';
+  if (/chevron-down/i.test(svgClass)) return; // already expanded
+  await arrow.click({ force: true });
+  await page.waitForTimeout(250);
+}
+
+test.describe('Postman Import/Export Round-Trip', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForApp(page);
+  });
+
+  // ---------- Scenario 1: roundtrip-postman-v2.1 ----------
+  test('roundtrip-postman-v2.1 — fixture imports with auth, scripts, variables, folders intact and exports back', async ({ page }) => {
+    const fixture = loadFixture('postman-v2.1-roundtrip.json');
+    // Deep-clone and suffix the collection name with a timestamp so parallel test runs don't collide.
+    const cloned = JSON.parse(JSON.stringify(fixture));
+    const rootName = `${cloned.info.name} ${timestamp}`;
+    cloned.info.name = rootName;
+
+    await importPostmanFile(page, cloned, 'postman-v2.1-roundtrip.json');
+
+    // The fixture has an APIKey request that triggers the "Import Warnings" modal.
+    // Dismiss it before interacting with the sidebar.
+    const warningsList = page.locator('[data-testid="confirm-list"]');
+    await expect(warningsList).toBeVisible({ timeout: 30000 });
+    await page.locator('.confirm-btn-confirm').click();
+    await expect(warningsList).not.toBeVisible({ timeout: 5000 });
+
+    // Wait for the import to finish and the collection to appear in the sidebar.
+    const rootHeader = page.locator('.collection-header').filter({ hasText: rootName });
+    await expect(rootHeader).toBeVisible({ timeout: 30000 });
+
+    // --- Verify root collection Variables tab has api_key and base_url ---
+    await rootHeader.locator('.collection-name').click();
+    await expect(page.locator('.collection-editor')).toBeVisible({ timeout: 5000 });
+    await page.locator('.collection-editor-tab').filter({ hasText: 'Variables' }).click();
+    await expect(page.locator('.collection-variables-tab')).toBeVisible({ timeout: 5000 });
+
+    const varsTable = page.locator('.collection-variables-tab .env-var-table tbody tr');
+    // Collect {key, value} for each row
+    const rowCount = await varsTable.count();
+    const rows: Array<{ key: string; value: string }> = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = varsTable.nth(i);
+      const k = await row.locator('td.col-key input').inputValue().catch(() => '');
+      const v = await row.locator('td.col-value input').inputValue().catch(() => '');
+      if (k) rows.push({ key: k, value: v });
+    }
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'api_key', value: 'abc123' }),
+        expect.objectContaining({ key: 'base_url', value: 'https://httpbin.org' }),
+      ])
+    );
+
+    // --- Expand the root collection and "Folder A" ---
+    // Root should be collapsed after opening its tab — click the arrow to expand.
+    await expandCollectionHeader(page, rootHeader);
+
+    const folderA = page.locator('.collection-header').filter({ hasText: 'Folder A' });
+    await expect(folderA).toBeVisible({ timeout: 5000 });
+    await expandCollectionHeader(page, folderA);
+
+    // --- Verify Bearer Request: auth_type=bearer with token 'req-token' ---
+    const bearerRequestItem = page.locator('.request-item').filter({ hasText: 'Bearer Request' });
+    await expect(bearerRequestItem).toBeVisible({ timeout: 5000 });
+    await bearerRequestItem.click();
+    await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+
+    await page.locator('.request-tabs button').filter({ hasText: 'Auth' }).click();
+    const bearerRadio = page.locator('.auth-type-selector label').filter({ hasText: 'Bearer Token' });
+    await expect(bearerRadio.locator('input[type="radio"]')).toBeChecked();
+    await expect(page.locator('.auth-token-field')).toHaveValue('req-token');
+
+    // --- Expand the SubFolder and verify Inherit Request ---
+    const subFolder = page.locator('.collection-header').filter({ hasText: 'SubFolder' });
+    await expect(subFolder).toBeVisible({ timeout: 5000 });
+    await expandCollectionHeader(page, subFolder);
+
+    const inheritRequestItem = page.locator('.request-item').filter({ hasText: 'Inherit Request' });
+    await expect(inheritRequestItem).toBeVisible({ timeout: 5000 });
+    await inheritRequestItem.click();
+    await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+    await page.locator('.request-tabs button').filter({ hasText: 'Auth' }).click();
+    const inheritRadio = page.locator('.auth-type-selector label').filter({ hasText: 'Inherit from Parent' });
+    await expect(inheritRadio.locator('input[type="radio"]')).toBeChecked();
+
+    // --- Verify NoAuth Request ---
+    const noAuthRequestItem = page.locator('.request-item').filter({ hasText: 'NoAuth Request' });
+    await expect(noAuthRequestItem).toBeVisible({ timeout: 5000 });
+    await noAuthRequestItem.click();
+    await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+    await page.locator('.request-tabs button').filter({ hasText: 'Auth' }).click();
+    const noAuthRadio = page.locator('.auth-type-selector label').filter({ hasText: 'No Auth' });
+    await expect(noAuthRadio.locator('input[type="radio"]')).toBeChecked();
+
+    // --- Verify Scripted Request has pre/post-script populated ---
+    const scriptedRequestItem = page.locator('.request-item').filter({ hasText: 'Scripted Request' });
+    await expect(scriptedRequestItem).toBeVisible({ timeout: 5000 });
+    await scriptedRequestItem.click();
+    await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+
+    await page.locator('.request-tabs button').filter({ hasText: 'Pre-script' }).click();
+    await expect(page.locator('.script-editor-wrapper')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.script-codemirror .cm-content')).toContainText('req pre');
+
+    await page.locator('.request-tabs button').filter({ hasText: 'Post-script' }).click();
+    await expect(page.locator('.script-editor-wrapper')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.script-codemirror .cm-content')).toContainText('req post');
+
+    // --- Trigger Export and capture the downloaded JSON ---
+    // Click the root header's menu to open the collection menu.
+    await rootHeader.hover();
+    const moreBtn = rootHeader.locator('.btn-menu');
+    await expect(moreBtn).toBeVisible();
+    await moreBtn.click();
+    const menu = page.locator('.collection-menu');
+    await expect(menu).toBeVisible();
+
+    // Capture the export download. Playwright runs in browser mode (not Tauri),
+    // so the browser-path download handler is deterministic here — failure to
+    // capture should fail the test rather than silently skip the assertions.
+    const downloadPromise = page.waitForEvent('download', { timeout: 15000 });
+    await menu.locator('.request-menu-item').filter({ hasText: 'Export' }).click();
+    const download = await downloadPromise;
+    const stream = await download.createReadStream();
+    expect(stream).toBeTruthy();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as any) chunks.push(Buffer.from(chunk));
+    const exportedJson: any = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+
+    {
+      // --- Structural equality on key fields, allowing UUID differences ---
+      // Root auth
+      expect(exportedJson.auth).toMatchObject({
+        type: 'bearer',
+        bearer: expect.arrayContaining([
+          expect.objectContaining({ key: 'token', value: 'root-token' }),
+        ]),
+      });
+
+      // Root events (pre & post)
+      expect(Array.isArray(exportedJson.event)).toBe(true);
+      const listeners = (exportedJson.event || []).map((e: any) => e.listen);
+      expect(listeners).toEqual(expect.arrayContaining(['prerequest', 'test']));
+
+      // Root variables
+      expect(Array.isArray(exportedJson.variable)).toBe(true);
+      const varKeys = (exportedJson.variable || []).map((v: any) => v.key);
+      expect(varKeys).toEqual(expect.arrayContaining(['api_key', 'base_url']));
+      const apiKeyVar = exportedJson.variable.find((v: any) => v.key === 'api_key');
+      expect(apiKeyVar).toMatchObject({ value: 'abc123' });
+
+      // Folder hierarchy: Folder A with SubFolder + Bearer Request
+      const items = exportedJson.item || [];
+      const folderAItem = items.find((i: any) => i.name === 'Folder A');
+      expect(folderAItem).toBeTruthy();
+      expect(Array.isArray(folderAItem.item)).toBe(true);
+      const bearerReqItem = folderAItem.item.find((i: any) => i.name === 'Bearer Request');
+      expect(bearerReqItem).toBeTruthy();
+      expect(bearerReqItem.request?.auth).toMatchObject({
+        type: 'bearer',
+        bearer: expect.arrayContaining([
+          expect.objectContaining({ key: 'token', value: 'req-token' }),
+        ]),
+      });
+      const subFolderItem = folderAItem.item.find((i: any) => i.name === 'SubFolder');
+      expect(subFolderItem).toBeTruthy();
+      const inheritItem = (subFolderItem.item || []).find((i: any) => i.name === 'Inherit Request');
+      expect(inheritItem).toBeTruthy();
+      // Inherit request should NOT have an auth field (or it should be null/undefined — Postman's inherit marker)
+      expect(inheritItem.request?.auth == null).toBeTruthy();
+
+      // Root-level Scripted Request events
+      const scriptedItem = items.find((i: any) => i.name === 'Scripted Request');
+      expect(scriptedItem).toBeTruthy();
+      expect(Array.isArray(scriptedItem.event)).toBe(true);
+      const scriptedListeners = scriptedItem.event.map((e: any) => e.listen);
+      expect(scriptedListeners).toEqual(expect.arrayContaining(['prerequest', 'test']));
+    }
+
+    await page.screenshot({ path: 'e2e/screenshots/import-roundtrip.png' });
+  });
+
+  // ---------- Scenario 2: import-warnings-surface ----------
+  test('import-warnings-surface — basic and oauth2 auth produce warnings toast + modal', async ({ page }) => {
+    const fixture = loadFixture('postman-v2.1-unsupported-auth.json');
+    const cloned = JSON.parse(JSON.stringify(fixture));
+    const rootName = `${cloned.info.name} ${timestamp}-warn`;
+    cloned.info.name = rootName;
+
+    await importPostmanFile(page, cloned, 'postman-v2.1-unsupported-auth.json');
+
+    // Warnings modal opens directly (no intermediate toast)
+    const warningsList = page.locator('[data-testid="confirm-list"]');
+    await expect(warningsList).toBeVisible({ timeout: 15000 });
+    const listText = (await warningsList.textContent()) || '';
+    expect(listText.toLowerCase()).toContain('basic');
+    expect(listText.toLowerCase()).toContain('oauth');
+
+    // Dismiss
+    const confirmBtn = page.locator('.confirm-btn-confirm');
+    await expect(confirmBtn).toBeVisible();
+    await confirmBtn.click();
+    await expect(warningsList).not.toBeVisible({ timeout: 5000 });
+
+    // Collection should now be visible in sidebar
+    const rootHeader = page.locator('.collection-header').filter({ hasText: rootName });
+    await expect(rootHeader).toBeVisible({ timeout: 15000 });
+
+    await page.screenshot({ path: 'e2e/screenshots/import-warnings.png' });
+  });
+
+  // ---------- Scenario 3: import-apikey-header ----------
+  test('import-apikey-header — apikey (in=header) is injected as a request header with a warning', async ({ page }) => {
+    const fixture = loadFixture('postman-v2.1-roundtrip.json');
+    const cloned = JSON.parse(JSON.stringify(fixture));
+    const rootName = `${cloned.info.name} ${timestamp}-apikey`;
+    cloned.info.name = rootName;
+
+    await importPostmanFile(page, cloned, 'postman-v2.1-roundtrip.json');
+
+    // Warnings modal opens directly with the API Key advisory
+    const warningsList = page.locator('[data-testid="confirm-list"]');
+    await expect(warningsList).toBeVisible({ timeout: 15000 });
+    const listText = (await warningsList.textContent()) || '';
+    expect(listText.toLowerCase()).toContain('api key');
+
+    // Close modal
+    const confirmBtn = page.locator('.confirm-btn-confirm');
+    await expect(confirmBtn).toBeVisible();
+    await confirmBtn.click();
+    await expect(warningsList).not.toBeVisible({ timeout: 5000 });
+
+    // Now find the imported collection in the sidebar
+    const rootHeader = page.locator('.collection-header').filter({ hasText: rootName });
+    await expect(rootHeader).toBeVisible({ timeout: 15000 });
+
+    // Expand root, open APIKey Request, check headers
+    await expandCollectionHeader(page, rootHeader);
+
+    const apiKeyRequestItem = page.locator('.request-item').filter({ hasText: 'APIKey Request' });
+    await expect(apiKeyRequestItem).toBeVisible({ timeout: 5000 });
+    await apiKeyRequestItem.click();
+    await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+
+    await page.locator('.request-tabs button').filter({ hasText: 'Headers' }).click();
+    const headersEditor = page.locator('.headers-editor');
+    await expect(headersEditor).toBeVisible({ timeout: 5000 });
+
+    // Find the row whose key input contains 'X-API-Key' and assert its value
+    const headerRows = headersEditor.locator('tbody tr');
+    const count = await headerRows.count();
+    let found = false;
+    for (let i = 0; i < count; i++) {
+      const row = headerRows.nth(i);
+      const keyInput = row.locator('td input[type="text"]').first();
+      const key = await keyInput.inputValue().catch(() => '');
+      if (key === 'X-API-Key') {
+        // Value input is inside an EnvVariableInput — pick the visible text input in this row.
+        const valueInputs = row.locator('input[type="text"], input:not([type])');
+        const n = await valueInputs.count();
+        for (let j = 0; j < n; j++) {
+          const v = await valueInputs.nth(j).inputValue().catch(() => '');
+          if (v === 'secret123') {
+            found = true;
+            break;
+          }
+        }
+        break;
+      }
+    }
+    expect(found).toBe(true);
+
+    await page.screenshot({ path: 'e2e/screenshots/import-apikey-header.png' });
+  });
+});

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -29,6 +29,7 @@ export function ConfirmProvider({ children }) {
     cancelText = 'Cancel',
     variant = 'default',
     listItems,
+    hideCancel = false,
   }) => {
     return new Promise((resolve) => {
       setState({
@@ -39,6 +40,7 @@ export function ConfirmProvider({ children }) {
         cancelText,
         variant,
         listItems,
+        hideCancel,
         resolve,
       });
     });
@@ -65,6 +67,7 @@ export function ConfirmProvider({ children }) {
           cancelText={state.cancelText}
           variant={state.variant}
           listItems={state.listItems}
+          hideCancel={state.hideCancel}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
         />
@@ -80,6 +83,7 @@ function ConfirmModal({
   cancelText,
   variant,
   listItems,
+  hideCancel,
   onConfirm,
   onCancel,
 }) {
@@ -126,12 +130,14 @@ function ConfirmModal({
         </div>
 
         <div className="confirm-footer">
-          <button
-            className="confirm-btn confirm-btn-cancel"
-            onClick={onCancel}
-          >
-            {cancelText}
-          </button>
+          {!hideCancel && (
+            <button
+              className="confirm-btn confirm-btn-cancel"
+              onClick={onCancel}
+            >
+              {cancelText}
+            </button>
+          )}
           <button
             className={`confirm-btn confirm-btn-confirm ${variant === 'danger' ? 'confirm-btn-danger' : ''}`}
             onClick={onConfirm}

--- a/src/data/supabase/sync.js
+++ b/src/data/supabase/sync.js
@@ -1,6 +1,10 @@
 // Import/Export + Realtime subscriptions
 import { supabase } from './client.js';
 import { checkAuth } from './helpers.js';
+import { getCollections } from './collections.js';
+import { getRequests } from './requests.js';
+import { getExamples } from './examples.js';
+import { getCollectionVariables } from './collectionVars.js';
 
 // Import/Export
 // Helper: Parse URL into Postman format
@@ -19,8 +23,33 @@ function parseUrl(urlString) {
   }
 }
 
+// Build a Postman-shaped `auth` object from our auth_type / auth_token.
+// Returns `undefined` to signal "omit the field" (our "inherit" maps to omission),
+// `null` to signal an explicit noauth override when a parent has auth.
+function buildPostmanAuth(authType, authToken, parentAuth) {
+  if (authType === 'bearer' && authToken) {
+    return { type: 'bearer', bearer: [{ key: 'token', value: authToken, type: 'string' }] };
+  }
+  if (authType === 'none' && parentAuth) {
+    return { type: 'noauth' };
+  }
+  // 'inherit' or 'none' with no parent auth → omit entirely
+  return undefined;
+}
+
+function buildPostmanEvents(preScript, postScript) {
+  const event = [];
+  if (preScript) {
+    event.push({ listen: 'prerequest', script: { type: 'text/javascript', exec: preScript.split('\n') } });
+  }
+  if (postScript) {
+    event.push({ listen: 'test', script: { type: 'text/javascript', exec: postScript.split('\n') } });
+  }
+  return event;
+}
+
 // Helper: Build Postman request format
-function buildPostmanRequest(req, examples) {
+function buildPostmanRequest(req, examples, parentAuth) {
   const headers = Array.isArray(req.headers) ? req.headers : [];
 
   const request = {
@@ -44,7 +73,10 @@ function buildPostmanRequest(req, examples) {
     };
   }
 
-  return {
+  const auth = buildPostmanAuth(req.auth_type, req.auth_token, parentAuth);
+  if (auth !== undefined) request.auth = auth;
+
+  const item = {
     name: req.name,
     request,
     response: examples.map(ex => {
@@ -72,34 +104,72 @@ function buildPostmanRequest(req, examples) {
       };
     }),
   };
+
+  const event = buildPostmanEvents(req.pre_script, req.post_script);
+  if (event.length > 0) item.event = event;
+
+  return item;
 }
 
-// Helper: Build Postman Collection v2.1 format
-function buildPostmanCollection(collection, allCollections, allRequests, allExamples) {
+// Helper: Build Postman Collection v2.1 format.
+// `allVariables` is the root collection's variables (only emitted on the root).
+// `parentAuth` threads the effective auth down so nested items can decide
+// whether emitting `{ type: 'noauth' }` is meaningful.
+function buildPostmanCollection(collection, allCollections, allRequests, allExamples, allVariables, parentAuth = null) {
+  const myAuth = buildPostmanAuth(collection.auth_type, collection.auth_token, parentAuth);
+  // effectiveAuth threaded to children: bearer on this level wins; an explicit
+  // 'none' override clears inherited auth; otherwise children keep inheriting.
+  let effectiveAuth;
+  if (collection.auth_type === 'bearer' && collection.auth_token) {
+    effectiveAuth = { type: 'bearer', bearer: [{ key: 'token', value: collection.auth_token, type: 'string' }] };
+  } else if (collection.auth_type === 'none') {
+    effectiveAuth = null;
+  } else {
+    effectiveAuth = parentAuth;
+  }
+
   const collectionRequests = allRequests.filter(r => r.collection_id === collection.id);
   const childCollections = allCollections.filter(c => c.parent_id === collection.id);
 
   const items = [
-    // Add requests
     ...collectionRequests.map(req => {
       const reqExamples = allExamples.filter(e => e.request_id === req.id);
-      return buildPostmanRequest(req, reqExamples);
+      return buildPostmanRequest(req, reqExamples, effectiveAuth);
     }),
-    // Add child folders recursively
-    ...childCollections.map(child => ({
-      name: child.name,
-      item: buildPostmanCollection(child, allCollections, allRequests, allExamples).item,
-    })),
+    ...childCollections.map(child => {
+      const inner = buildPostmanCollection(child, allCollections, allRequests, allExamples, allVariables, effectiveAuth);
+      const folder = { name: child.name, item: inner.item };
+      if (inner.auth) folder.auth = inner.auth;
+      if (inner.event) folder.event = inner.event;
+      return folder;
+    }),
   ];
 
-  return {
-    info: {
-      _postman_id: collection.id,
-      name: collection.name,
-      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
-    },
-    item: items,
-  };
+  const isRoot = !collection.parent_id;
+  const result = isRoot
+    ? {
+        info: {
+          _postman_id: collection.id,
+          name: collection.name,
+          schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+        },
+        item: items,
+      }
+    : { item: items };
+
+  if (myAuth !== undefined) result.auth = myAuth;
+
+  const event = buildPostmanEvents(collection.pre_script, collection.post_script);
+  if (event.length > 0) result.event = event;
+
+  if (isRoot && Array.isArray(allVariables) && allVariables.length > 0) {
+    const vars = allVariables
+      .filter(v => v.enabled !== false && v.key)
+      .map(v => ({ key: v.key, value: v.value || v.initial_value || '', type: 'string' }));
+    if (vars.length > 0) result.variable = vars;
+  }
+
+  return result;
 }
 
 export const exportCollection = async (id) => {
@@ -112,7 +182,15 @@ export const exportCollection = async (id) => {
     throw new Error('Collection not found');
   }
 
-  return buildPostmanCollection(rootCollection, allCollections, allRequests, allExamples);
+  let allVariables = [];
+  try {
+    allVariables = await getCollectionVariables(id);
+  } catch {
+    // Non-fatal — export without variables rather than aborting
+    allVariables = [];
+  }
+
+  return buildPostmanCollection(rootCollection, allCollections, allRequests, allExamples, allVariables);
 };
 
 export const importCollection = async (postmanData, workspaceId = null) => {

--- a/src/hooks/useRequestActions.js
+++ b/src/hooks/useRequestActions.js
@@ -629,6 +629,7 @@ export function useRequestActions({
     const loadingToast = toast.loading('Importing collection...');
     try {
       const result = await data.importCollection(importData, activeWorkspace?.id);
+      const collectionName = importData?.info?.name || 'Collection';
       // Fetch the newly imported collection tree and add to state
       if (result.rootCollectionId) {
         markAsRecentlyModified(`collection-${result.rootCollectionId}`);
@@ -643,12 +644,26 @@ export function useRequestActions({
         });
       }
       toast.dismiss(loadingToast);
-      toast.success('Collection imported successfully');
+
+      const warnings = Array.isArray(result.warnings) ? result.warnings : [];
+      if (warnings.length > 0) {
+        // Info-only modal so users see exactly which Postman features didn't round-trip
+        await confirm({
+          title: 'Import Warnings',
+          message: `Imported "${collectionName}" with ${warnings.length} warning${warnings.length === 1 ? '' : 's'}.`,
+          listItems: warnings,
+          confirmText: 'OK',
+          hideCancel: true,
+          variant: 'default',
+        });
+      } else {
+        toast.success(`Imported "${collectionName}"`);
+      }
     } catch (err) {
       toast.dismiss(loadingToast);
       toast.error(err.message || 'Failed to import collection');
     }
-  }, [activeWorkspace, markAsRecentlyModified, setCollections, toast]);
+  }, [activeWorkspace, confirm, markAsRecentlyModified, setCollections, toast]);
 
   const handleExportCollection = useCallback(async (collection) => {
     const loadingToast = toast.loading('Exporting collection...');

--- a/supabase/functions/import-collection/index.ts
+++ b/supabase/functions/import-collection/index.ts
@@ -6,31 +6,58 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
+interface PostmanAuthKV {
+  key: string;
+  value: string;
+  type?: string;
+}
+
+interface PostmanAuth {
+  type?: string;
+  bearer?: PostmanAuthKV[];
+  apikey?: PostmanAuthKV[];
+  basic?: PostmanAuthKV[];
+  oauth2?: PostmanAuthKV[];
+  oauth1?: PostmanAuthKV[];
+}
+
+interface PostmanEvent {
+  listen?: string;
+  script?: { type?: string; exec?: string | string[] };
+}
+
+interface PostmanHeader {
+  key: string;
+  value: string;
+  disabled?: boolean;
+}
+
 interface PostmanRequest {
   method?: string;
   url?: string | { raw?: string };
-  header?: Array<{ key: string; value: string; disabled?: boolean }>;
+  header?: PostmanHeader[];
   body?: {
     mode?: string;
     raw?: string;
     formdata?: Array<{ key: string; value?: string; type?: string; src?: string; disabled?: boolean }>;
   };
-  auth?: {
-    type?: string;
-    bearer?: Array<{ key: string; value: string }>;
-  };
+  auth?: PostmanAuth;
 }
 
 interface PostmanItem {
   name?: string;
   request?: PostmanRequest;
   item?: PostmanItem[];
+  auth?: PostmanAuth;
+  event?: PostmanEvent[];
 }
 
 interface PostmanCollection {
   info?: { name?: string };
   item?: PostmanItem[];
-  variable?: Array<{ key: string; value: string }>;
+  variable?: Array<{ key: string; value?: string }>;
+  auth?: PostmanAuth;
+  event?: PostmanEvent[];
 }
 
 interface CollectionRecord {
@@ -38,6 +65,10 @@ interface CollectionRecord {
   name: string;
   parent_id: string | null;
   workspace_id: string | null;
+  auth_type: string;
+  auth_token: string;
+  pre_script: string;
+  post_script: string;
   created_at: number;
   updated_at: number;
 }
@@ -55,39 +86,145 @@ interface RequestRecord {
   params: string;
   auth_type: string;
   auth_token: string;
+  pre_script: string;
+  post_script: string;
   sort_order: number;
   created_at: number;
   updated_at: number;
 }
 
-// Parse Postman collection recursively and collect all collections and requests
+interface CollectionVariableRecord {
+  id: string;
+  collection_id: string;
+  key: string;
+  initial_value: string;
+  enabled: boolean;
+  sort_order: number;
+  created_at: number;
+  updated_at: number;
+}
+
+interface AuthParseResult {
+  auth_type: string;
+  auth_token: string;
+  injectedHeaders: PostmanHeader[];
+}
+
+// Map a Postman auth block to our storage shape.
+// `parentHasAuth` lets us distinguish "no auth block, parent has one" (inherit)
+// from "no auth block, no parent either" (none). API Key in=header is injected
+// into the request's headers as a best-effort mapping.
+function parseAuth(
+  auth: PostmanAuth | undefined | null,
+  parentHasAuth: boolean,
+  warnings: string[],
+  context: string
+): AuthParseResult {
+  if (!auth) {
+    return parentHasAuth
+      ? { auth_type: 'inherit', auth_token: '', injectedHeaders: [] }
+      : { auth_type: 'none', auth_token: '', injectedHeaders: [] };
+  }
+  if (auth.type === 'noauth') {
+    return { auth_type: 'none', auth_token: '', injectedHeaders: [] };
+  }
+  if (auth.type === 'bearer' && Array.isArray(auth.bearer)) {
+    const tokenItem = auth.bearer.find((b) => b.key === 'token');
+    return { auth_type: 'bearer', auth_token: tokenItem?.value || '', injectedHeaders: [] };
+  }
+  if (auth.type === 'apikey' && Array.isArray(auth.apikey)) {
+    const keyEntry = auth.apikey.find((a) => a.key === 'key');
+    const valueEntry = auth.apikey.find((a) => a.key === 'value');
+    const inEntry = auth.apikey.find((a) => a.key === 'in');
+    const location = inEntry?.value || 'header';
+    if (location === 'header' && keyEntry?.value) {
+      warnings.push(
+        `${context}: API Key auth mapped to header "${keyEntry.value}". Review the generated header if needed.`
+      );
+      return {
+        auth_type: 'none',
+        auth_token: '',
+        injectedHeaders: [{ key: keyEntry.value, value: valueEntry?.value || '' }],
+      };
+    }
+    warnings.push(
+      `${context}: API Key auth with location "${location}" is not supported — dropped. Re-add manually as a query param.`
+    );
+    return { auth_type: 'none', auth_token: '', injectedHeaders: [] };
+  }
+  if (auth.type === 'basic') {
+    warnings.push(`${context}: Basic auth is not supported yet — dropped.`);
+    return { auth_type: 'none', auth_token: '', injectedHeaders: [] };
+  }
+  if (auth.type === 'oauth2' || auth.type === 'oauth1') {
+    warnings.push(
+      `${context}: OAuth auth is not supported — dropped. You'll need to configure auth manually.`
+    );
+    return { auth_type: 'none', auth_token: '', injectedHeaders: [] };
+  }
+  warnings.push(`${context}: Unknown auth type "${auth.type}" — dropped.`);
+  return { auth_type: 'none', auth_token: '', injectedHeaders: [] };
+}
+
+function parseEvents(event: PostmanEvent[] | undefined): { pre_script: string; post_script: string } {
+  if (!Array.isArray(event)) return { pre_script: '', post_script: '' };
+  let pre_script = '';
+  let post_script = '';
+  for (const ev of event) {
+    const exec = ev?.script?.exec;
+    const code = Array.isArray(exec) ? exec.join('\n') : (exec || '');
+    if (ev.listen === 'prerequest') pre_script = code;
+    else if (ev.listen === 'test') post_script = code;
+  }
+  return { pre_script, post_script };
+}
+
+// Parse Postman collection recursively and collect all collections and requests.
+// `parentHasAuth` is true when any ancestor (including this level on the way down)
+// declared a concrete auth block — used so missing `auth` on descendants maps
+// to `inherit` rather than `none`.
 function parseCollection(
   data: PostmanCollection | PostmanItem,
   parentId: string | null,
   workspaceId: string | null,
+  parentHasAuth: boolean,
   collections: CollectionRecord[],
   requests: RequestRecord[],
+  warnings: string[],
   now: number
 ): string {
   const collectionId = crypto.randomUUID();
   const name = (data as PostmanCollection).info?.name || (data as PostmanItem).name || 'Imported Collection';
+
+  // Folder/collection-level auth + events
+  const rawAuth = (data as PostmanItem).auth || (data as PostmanCollection).auth;
+  const authResult = parseAuth(rawAuth, parentHasAuth, warnings, `${parentId ? 'Folder' : 'Collection'} "${name}"`);
+  const { pre_script, post_script } = parseEvents((data as PostmanItem).event || (data as PostmanCollection).event);
 
   collections.push({
     id: collectionId,
     name,
     parent_id: parentId,
     workspace_id: parentId ? null : workspaceId, // Only root gets workspace_id
+    auth_type: authResult.auth_type,
+    auth_token: authResult.auth_token,
+    pre_script,
+    post_script,
     created_at: now,
     updated_at: now,
   });
+
+  // A concrete auth here (bearer, etc.) establishes auth for descendants.
+  // 'none' with injected headers does not count as auth for inherit purposes.
+  const childParentHasAuth = parentHasAuth || authResult.auth_type === 'bearer';
 
   const items = (data as PostmanCollection).item || [];
   let sortOrder = 0;
 
   for (const item of items) {
     if (item.request) {
-      // It's a request
       const req = item.request;
+      const reqName = item.name || 'Unnamed Request';
 
       let url = '';
       if (typeof req.url === 'string') {
@@ -121,18 +258,18 @@ function parseCollection(
         }
       }
 
-      let authType = 'none';
-      let authToken = '';
-      if (req.auth?.type === 'bearer' && req.auth.bearer) {
-        authType = 'bearer';
-        const tokenItem = req.auth.bearer.find(b => b.key === 'token');
-        authToken = tokenItem?.value || '';
+      const reqAuthResult = parseAuth(req.auth, childParentHasAuth, warnings, `Request "${reqName}"`);
+      // Inject apikey-as-header into the header list
+      for (const h of reqAuthResult.injectedHeaders) {
+        headers.push({ key: h.key, value: h.value, enabled: true });
       }
+
+      const { pre_script: reqPre, post_script: reqPost } = parseEvents(item.event);
 
       requests.push({
         id: crypto.randomUUID(),
         collection_id: collectionId,
-        name: item.name || 'Unnamed Request',
+        name: reqName,
         method: (req.method || 'GET').toUpperCase(),
         url,
         headers: JSON.stringify(headers),
@@ -140,20 +277,29 @@ function parseCollection(
         body_type: bodyType,
         form_data: JSON.stringify(formData),
         params: JSON.stringify([]),
-        auth_type: authType,
-        auth_token: authToken,
+        auth_type: reqAuthResult.auth_type,
+        auth_token: reqAuthResult.auth_token,
+        pre_script: reqPre,
+        post_script: reqPost,
         sort_order: sortOrder++,
         created_at: now,
         updated_at: now,
       });
     } else if (item.item) {
-      // It's a folder/sub-collection
+      // Folder/sub-collection: carry folder-level auth + events through.
       parseCollection(
-        { info: { name: item.name }, item: item.item } as PostmanCollection,
+        {
+          info: { name: item.name },
+          item: item.item,
+          auth: item.auth,
+          event: item.event,
+        } as PostmanCollection,
         collectionId,
         null,
+        childParentHasAuth,
         collections,
         requests,
+        warnings,
         now
       );
     }
@@ -232,15 +378,38 @@ Deno.serve(async (req: Request) => {
     const now = Math.floor(Date.now() / 1000);
     const collections: CollectionRecord[] = [];
     const requests: RequestRecord[] = [];
+    const warnings: string[] = [];
 
     const rootCollectionId = parseCollection(
       postmanData,
       null,
       workspaceId,
+      false,
       collections,
       requests,
+      warnings,
       now
     );
+
+    // Build collection_variables rows (root-scoped)
+    const collectionVariables: CollectionVariableRecord[] = [];
+    if (Array.isArray(postmanData.variable) && postmanData.variable.length > 0) {
+      postmanData.variable.forEach((v: { key?: string; value?: string }, index: number) => {
+        if (!v || !v.key) return;
+        collectionVariables.push({
+          id: crypto.randomUUID(),
+          collection_id: rootCollectionId,
+          key: v.key,
+          initial_value: v.value || '',
+          enabled: true,
+          sort_order: index,
+          created_at: now,
+          updated_at: now,
+        });
+      });
+      // Note: collection variables imported successfully — no warning emitted
+      // (informational message was noisy and pushed real warnings below the fold).
+    }
 
     // Batch insert all collections
     if (collections.length > 0) {
@@ -276,45 +445,27 @@ Deno.serve(async (req: Request) => {
       }
     }
 
-    // Import environment variables if present
-    let environment = null;
-    if (postmanData.variable && postmanData.variable.length > 0 && workspaceId) {
-      const envId = crypto.randomUUID();
-      const envName = `${collectionName} Variables`;
+    // Batch insert collection variables (non-fatal if it fails — log a warning)
+    if (collectionVariables.length > 0) {
+      const { error: varError } = await adminClient
+        .from("collection_variables")
+        .insert(collectionVariables);
 
-      // Create environment
-      const { error: envError } = await adminClient
-        .from("environments")
-        .insert({
-          id: envId,
-          name: envName,
-          workspace_id: workspaceId,
-          created_by: currentUser.id,
-          updated_by: currentUser.id,
-          created_at: now,
-          updated_at: now,
-        });
+      if (varError) {
+        // Roll back collections + requests to keep state consistent
+        await adminClient
+          .from("requests")
+          .delete()
+          .in("id", requests.map(r => r.id));
+        await adminClient
+          .from("collections")
+          .delete()
+          .in("id", collections.map(c => c.id));
 
-      if (!envError) {
-        // Create environment variables
-        const envVars = postmanData.variable.map((v: { key: string; value?: string }, index: number) => ({
-          id: crypto.randomUUID(),
-          environment_id: envId,
-          key: v.key,
-          initial_value: v.value || '',
-          enabled: true,
-          sort_order: index,
-          created_at: now,
-          updated_at: now,
-        }));
-
-        if (envVars.length > 0) {
-          await adminClient
-            .from("environment_variables")
-            .insert(envVars);
-        }
-
-        environment = { id: envId, name: envName };
+        return new Response(
+          JSON.stringify({ message: `Failed to import collection variables: ${varError.message}` }),
+          { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
       }
     }
 
@@ -324,7 +475,10 @@ Deno.serve(async (req: Request) => {
         rootCollectionId,
         collectionsCount: collections.length,
         requestsCount: requests.length,
-        environment,
+        // `environment` was the pre-0.1.12 behavior — variables now import as
+        // collection variables instead. Kept as null for response-shape stability.
+        environment: null,
+        warnings,
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );


### PR DESCRIPTION
Part 1 of 3 for #30. Does NOT close the umbrella issue — PR #2 (format picker + Insomnia) and PR #3 (OpenAPI importer) still to come.

## Summary
The existing Postman import/export round-trip silently dropped auth, scripts, variables, and inherit semantics. This PR repairs that path before the multi-format importer rides on top of it, and wires a warnings channel so dropped fields are no longer invisible to the user.

## Export — `src/data/supabase/sync.js`
- Bearer auth → `auth.bearer` on requests and collections.
- `auth_type='inherit'` → omit the `auth` field entirely (Postman's inherit marker).
- `auth_type='none'` on a child whose parent has auth → emit `{type:'noauth'}` so the explicit override survives.
- Pre/post scripts → `event[]` with `listen: 'prerequest' | 'test'`.
- Collection variables → `variable[]` at the root.
- `effectiveAuth` threaded through the collection recursion so inherit semantics round-trip.

## Import — `supabase/functions/import-collection/index.ts`
- `parseAuth` covers bearer / noauth / apikey (header: injected as header + warning, query: warning only) / basic / oauth1 / oauth2 / unknown. Every unsupported type emits a warning naming the request or collection context.
- `parseEvents` maps Postman's `event[]` back into `pre_script` / `post_script` at both request and collection level.
- `parentHasAuth` threaded so missing `auth` on a child with an auth ancestor becomes `auth_type='inherit'`.
- Collection-level `variable[]` now lands as Post Umbrella **collection variables** on the root collection, not a new Environment (**breaking change** — see CHANGELOG).
- `warnings[]` accumulated during parsing and returned in the response.
- Rollback extended to also delete imported collection_variables on failure.

## Client UX — `src/hooks/useRequestActions.js` + `src/components/ConfirmModal.jsx`
- When the server returns warnings, open an **Import Warnings** modal listing each warning (reusing the `listItems` prop shipped in #28). New optional `hideCancel` prop on ConfirmModal so the info-only dismissal has just an OK button.
- No warnings → existing success toast.

## Breaking change
Postman files with `variable[]` at the collection level previously created a new Environment named `"<Collection> Variables"` during import. After this PR they create Post Umbrella collection variables on the imported root collection (matching the v0.1.8 collection-variables feature). Documented at the top of the CHANGELOG.

## Deferred to follow-up PRs
- Format picker UI + Insomnia parser + normalization layer for foreign templating tags (\`{% response ... %}\`, \`{{$guid}}\`) → PR #2
- OpenAPI / Swagger importer → PR #3
- Workflow export (no Postman equivalent, needs a design decision)

## Test plan
- [x] New E2E: `e2e/import-roundtrip.spec.ts` — round-trip persistence + structural equality of exported JSON (auth, event, variable, folder hierarchy), warnings-surface, apikey header injection. 3/3 pass.
- [x] Regression: `e2e/import.spec.ts`, `e2e/collection.spec.ts`, `e2e/collection-auth.spec.ts`, `e2e/collection-variables.spec.ts` — 14/14 pass.
- [x] No AI attribution, no debug artifacts.

## Files
- New: \`acceptance/import-roundtrip-repair.md\`
- New: \`e2e/fixtures/imports/postman-v2.1-roundtrip.json\`, \`postman-v2.1-unsupported-auth.json\`
- New: \`e2e/import-roundtrip.spec.ts\`
- Modified: \`src/data/supabase/sync.js\`, \`supabase/functions/import-collection/index.ts\`, \`src/components/ConfirmModal.jsx\`, \`src/hooks/useRequestActions.js\`, \`CHANGELOG.md\`