### PR TITLE
release: v0.1.13 — OpenAPI/Swagger import, Insomnia, multi-format picker, tab context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,29 @@
 # Changelog
 
-## Unreleased
+## v0.1.13
 
 ### New
 
-- **OpenAPI / Swagger Import** — Import OpenAPI 3.x or Swagger 2.x specs (JSON or YAML) via the Import Modal. Tags map to folders, `servers[0].url` seeds a `{{baseUrl}}` collection variable, path parameters become `{{param}}`, security schemes map to Bearer auth or API Key headers/query. Request/response examples carry through when the spec provides them. Closes #30. (#30)
-- **Multi-Format Import Modal** — Import now opens a step-by-step modal where you pick the source format (Postman, Insomnia, Post Umbrella; OpenAPI reserved for a future release), upload a file, preview the outcome (collection/folder/request/variable counts + warnings list), and confirm before anything is written. The old implicit "pick any JSON and hope" flow is replaced by explicit format selection + schema validation. (#30)
-- **Insomnia v4 Import** — Full Insomnia v4 export parsing: workspaces, request groups (folders), requests (method/URL/headers/body/auth), and base environment variables. Insomnia `{% response 'body', 'req_<id>', 'b64::<jsonpath>::<hash>' %}` template tags are automatically rewritten: the producing request gains a post-response script that extracts the referenced value and saves it as a collection variable, while the consuming request's token becomes `{{slug_token}}`. Unresolvable tags become `{{TODO_FIX_insomnia_response}}` with a warning. Other Insomnia tags (`{% uuid %}`, `{% timestamp %}`, etc.) map to their Postman equivalents or `{{TODO_FIX_...}}` placeholders. (#30)
-- **Schema Validation on Import** — Every import file is validated against a bundled JSON Schema before any DB write (Postman v2.1/v2.0, Insomnia v4, Post Umbrella v1). Validation failures surface in a detailed error panel listing the JSON path and expected shape for each problem. (#30)
-- **Postman Dynamic Variable Seeding** — `{{$guid}}`, `{{$timestamp}}`, `{{$randomInt}}`, `{{$randomUUID}}`, `{{$isoTimestamp}}` in imported Postman files auto-seed matching collection variables. Unknown dynamics produce a warning. (#30)
+- **OpenAPI / Swagger Import** — Import OpenAPI 3.x or Swagger 2.x specs (JSON or YAML) via the Import Modal. Tags map to folders, `servers[0].url` seeds a `{{baseUrl}}` collection variable, path parameters become `{{param}}`, security schemes map to Bearer auth or API Key headers/query. Request/response examples carry through when the spec provides them. Closes #30. (#30, #33)
+- **Multi-Format Import Modal** — Import now opens a step-by-step modal where you pick the source format (Postman, Insomnia, Post Umbrella, OpenAPI/Swagger), upload a file, preview the outcome (collection/folder/request/variable counts + warnings list), and confirm before anything is written. The old implicit "pick any JSON and hope" flow is replaced by explicit format selection + schema validation. (#30, #32)
+- **Insomnia v4 Import** — Full Insomnia v4 export parsing: workspaces, request groups (folders), requests (method/URL/headers/body/auth), and base environment variables. Insomnia `{% response 'body', 'req_<id>', 'b64::<jsonpath>::<hash>' %}` template tags are automatically rewritten: the producing request gains a post-response script that extracts the referenced value and saves it as a collection variable, while the consuming request's token becomes `{{slug_token}}`. Unresolvable tags become `{{TODO_FIX_insomnia_response}}` with a warning. Other Insomnia tags (`{% uuid %}`, `{% timestamp %}`, etc.) map to their Postman equivalents or `{{TODO_FIX_...}}` placeholders. (#30, #32)
+- **Schema Validation on Import** — Every import file is validated against a bundled JSON Schema before any DB write (Postman v2.1/v2.0, Insomnia v4, Post Umbrella v1, OpenAPI 3.x / Swagger 2.x). Validation failures surface in a detailed error panel listing the JSON path and expected shape for each problem. (#30, #32, #33)
+- **Postman Dynamic Variable Seeding** — `{{$guid}}`, `{{$timestamp}}`, `{{$randomInt}}`, `{{$randomUUID}}`, `{{$isoTimestamp}}` in imported Postman files auto-seed matching collection variables. Unknown dynamics produce a warning. (#30, #32)
+- **Tab Right-Click Context Menu** — Right-clicking an open tab opens a menu with Close, Close Other Tabs, Close Unmodified Tabs, Close Tabs to the Left, and Close Tabs to the Right. Items hide when they would do nothing. Closing the active tab now shifts focus to its right neighbor (fallback left) for both the menu and the × button. Closes #27. (#28)
 
 ### Improved
 
-- **Postman Import/Export Round-Trip** — Exporting a collection now preserves bearer auth, `Inherit from Parent` auth, folder/collection-level auth, pre/post scripts (request and collection level), and collection variables. Importing recognizes Postman's `event[]` script format and maps API Key auth (header location) into a request header. Basic, OAuth 1.0, OAuth 2.0, and unknown auth types no longer silently drop — they surface a per-request warning in a new "Import Warnings" modal. Part 1 of 3 for #30. (#30)
-- **Export Performance** — `exportCollection` now fetches only the target collection's subtree instead of every collection in the workspace, fixing a pre-existing duplicate-folder bug and reducing DB reads. (#30)
+- **Postman Import/Export Round-Trip** — Exporting a collection now preserves bearer auth, `Inherit from Parent` auth, folder/collection-level auth, pre/post scripts (request and collection level), and collection variables. Importing recognizes Postman's `event[]` script format and maps API Key auth (header location) into a request header. Basic, OAuth 1.0, OAuth 2.0, and unknown auth types no longer silently drop — they surface a per-request warning in a new "Import Warnings" modal. (#30, #31)
+- **Export Performance** — `exportCollection` now fetches only the target collection's subtree instead of every collection in the workspace, fixing a pre-existing duplicate-folder bug and reducing DB reads. (#30, #31)
+
+### Fixed
+
+- **`null` / `undefined` / `NaN` Rendered as Empty in JSON Response Viewer** — `{ "key": null }` was showing up as `"key":` with nothing after the colon. Root cause is a bug in `@uiw/react-json-view@2.0.0-alpha.41`: `TypeNull` / `TypeUndefined` / `TypeNan` lack the value-text fallback that the other type components have, so when `displayDataTypes={false}` they render nothing at all. Worked around by providing explicit `render` overrides via the `JsonView.Null` / `Undefined` / `Nan` slots. Upstream bug filed as [uiwjs/react-json-view#91](https://github.com/uiwjs/react-json-view/issues/91).
 
 ### Breaking
 
-- **Postman collection-level `variable[]` now imports as collection variables.** Previously, importing a Postman file with top-level `variable[]` silently created a new Environment named `"<Collection> Variables"`. It now creates Post Umbrella collection variables on the imported root collection (matching the v0.1.8 collection-variables feature). Users who relied on the old behavior should recreate the environment manually or re-scope the values to collection variables. (#30)
-- **Import UX changed.** The old single-click "Collection File" import path is replaced by the new multi-step ImportModal. The "From cURL" flow is unchanged. (#30)
+- **Postman collection-level `variable[]` now imports as collection variables.** Previously, importing a Postman file with top-level `variable[]` silently created a new Environment named `"<Collection> Variables"`. It now creates Post Umbrella collection variables on the imported root collection (matching the v0.1.8 collection-variables feature). Users who relied on the old behavior should recreate the environment manually or re-scope the values to collection variables. (#30, #31)
+- **Import UX changed.** The old single-click "Collection File" import path is replaced by the new multi-step ImportModal. The "From cURL" flow is unchanged. (#30, #32)
 
 ## v0.1.12
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "post-umbrella"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-umbrella"
-version = "0.1.12"
+version = "0.1.13"
 description = "A self-hosted API testing tool"
 authors = ["emonster"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Post Umbrella",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "ca.emonster.post-umbrella",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
v0.1.13 rolls up the #30 import arc (3 merged PRs), the #27 tab context menu, and a JSON response viewer fix for null/undefined/NaN.

### New
- **OpenAPI / Swagger Import** — Import OpenAPI 3.x or Swagger 2.x specs (JSON or YAML). Tags → folders, `servers[0].url` → `{{baseUrl}}`, path params → `{{param}}`, security schemes → Bearer / API Key auth. Closes #30. (#33)
- **Multi-Format Import Modal** — Step-by-step modal: pick format (Postman / Insomnia / Post Umbrella / OpenAPI), upload, preview counts + warnings, confirm. Replaces the old implicit "pick any JSON and hope" path. (#32)
- **Insomnia v4 Import** — Full Insomnia v4 parsing including automatic rewriting of `{% response %}` template tags into post-response scripts + `{{slug_token}}` collection variables. Unresolvable tags become `{{TODO_FIX_insomnia_response}}` with a warning. (#32)
- **Schema Validation on Import** — Every file validated against a bundled JSON Schema (Postman v2.1/v2.0, Insomnia v4, Post Umbrella v1, OpenAPI 3.x / Swagger 2.x) before any DB write. (#32, #33)
- **Postman Dynamic Variable Seeding** — `{{$guid}}`, `{{$timestamp}}`, `{{$randomInt}}`, `{{$randomUUID}}`, `{{$isoTimestamp}}` auto-seed matching collection variables on import. (#32)
- **Tab Right-Click Context Menu** — Close / Close Other / Close Unmodified / Close to Left / Close to Right. Closing the active tab shifts focus to its right neighbor (fallback left). Closes #27. (#28)

### Improved
- **Postman Import/Export Round-Trip** — Exports now preserve bearer auth, Inherit-from-Parent auth, folder/collection-level auth, pre/post scripts, and collection variables. Imports recognize `event[]` scripts, map API Key (header) to a request header, and surface per-request warnings for Basic/OAuth 1.0/OAuth 2.0/unknown auth types in an "Import Warnings" modal. (#31)
- **Export Performance** — `exportCollection` now fetches only the target subtree instead of every workspace collection — fixes a pre-existing duplicate-folder bug and reduces DB reads. (#31)

### Fixed
- **`null` / `undefined` / `NaN` Rendered as Empty in JSON Response Viewer** — Root cause: `@uiw/react-json-view@2.0.0-alpha.41` bug — `TypeNull` / `TypeUndefined` / `TypeNan` lack the value-text fallback the other type components have, so with `displayDataTypes={false}` they render nothing. Worked around via explicit `JsonView.Null` / `Undefined` / `Nan` slot overrides. Upstream: [uiwjs/react-json-view#91](https://github.com/uiwjs/react-json-view/issues/91).

### Breaking
- **Postman collection-level `variable[]` now imports as collection variables** (previously silently created an Environment). Matches the v0.1.8 collection-variables feature.
- **Import UX changed.** Single-click "Collection File" is replaced by the multi-step ImportModal. "From cURL" is unchanged.

## Version bumps
- `src-tauri/tauri.conf.json` 0.1.12 → 0.1.13
- `src-tauri/Cargo.toml` 0.1.12 → 0.1.13
- `src-tauri/Cargo.lock` 0.1.12 → 0.1.13

## Release workflow
After squash-merge, tag on main:
```
git checkout main && git pull
git tag v0.1.13
git push origin v0.1.13
```
The `v*` tag push triggers `.github/workflows/release.yml` to build and publish desktop artifacts.

## Test plan
- [x] All three import PRs (#31, #32, #33) merged with passing E2E suites.
- [x] Tab context menu PR (#28) merged with passing E2E.
- [x] `npm run build` green with the null-fix wrapper in place.
- [ ] Verify `null` / `undefined` / `NaN` render as visible text in the JSON response viewer (manual, post-merge smoke).
- [ ] After tagging: verify release workflow builds Windows / macOS / Linux artifacts successfully.