### PR TITLE
feat: path variables in request URL

### DIFF
--- a/acceptance/path-variables.md
+++ b/acceptance/path-variables.md
@@ -1,0 +1,943 @@
+# Acceptance Spec: Path Variables in Request URL
+
+## Problem
+
+Today the URL input only supports `{{env}}` / `{{collection}}` substitution. There is no Postman-style path variable concept (`/users/:id`). Real REST APIs are heavily path-templated, so users currently work around this by storing path segments as env vars — clumsy and not scoped to a single request.
+
+Solution — add per-request **path variables** declared inline in the URL with `:name` syntax. Each `:name` token in the URL produces a row in a "Path Variables" list inside the Params tab (below the existing query params table). Keys are read-only in the list (edited only by editing the URL); values are editable directly or via the floating variable popover. Values may themselves reference `{{env}}` variables. Substitution applies to both the live request *and* the cURL preview.
+
+## Scope
+
+This spec covers **three sub-features** that ship in one PR (issue #38):
+
+- **F1 (foundation, no UX change)** — Supabase migration adding `path_variables JSONB` to `requests`, data layer parses/stringifies it, and substitution logic is extracted into a single shared util used by `useResponseExecution.js`, `useWorkflowExecution.js`, and `CurlPanel.jsx`. The util gains a path-var pass even though no UI yet writes to `path_variables` (the column will be empty `[]` for existing rows; the pass is a no-op for them).
+
+- **F2 (URL parsing UI)** — `RequestEditor.jsx` parses `:name` tokens from the URL on every change and reconciles the `pathVariables` array (add new, remove deleted, **preserve values** for surviving keys). New "Path Variables" section appears inside the Params tab below the query params table when `pathVariables.length > 0`. Reserved-character validation strips a `:` followed immediately by an invalid char. Save persists `path_variables`.
+
+- **F3 (overlay highlight + popover)** — `EnvVariableInput` recognizes `:name` in addition to `{{var}}` when caller passes `pathVariables` prop (URL field only — headers/body/value cells stay env-only). Hover/click on `:name` opens the existing `VariablePopover` showing the path-var value, editable inline. Distinct accent color (proposing `--accent-success` green) so users can tell env (blue) / collection (orange) / path (green) at a glance.
+
+Edit only:
+- New: `supabase/migrations/{timestamp}_request_path_variables.sql`, `src/utils/substituteVariables.js`, `e2e/path-variables.spec.ts`
+- Modified: `src/data/supabase/requests.js`, `src/hooks/useResponseExecution.js`, `src/hooks/useWorkflowExecution.js`, `src/components/CurlPanel.jsx`, `src/components/RequestEditor.jsx`, `src/components/EnvVariableInput.jsx`, `src/components/VariablePopover.jsx`, `src/styles/request-editor.css` (or `App.css`)
+
+No new dependencies.
+
+Out of scope:
+- Path variables on the workflow level (workflows still execute requests with each request's own path vars).
+- `pm.pathVariables.get/set` script API — defer.
+- Autocomplete dropdown after typing `:` (no list of suggestions). The variable list updates as the URL is typed; that's enough for v1.
+- Path variables in headers, body, or auth (path-var syntax only valid in the URL).
+- Importing/exporting path variables in Postman/cURL/OpenAPI sync — defer (the URL string round-trips fine; values won't but that's a follow-up).
+
+---
+
+## F1 — Storage and Substitution Foundation
+
+### Migration
+File: `supabase/migrations/{NEW-TIMESTAMP}_request_path_variables.sql` (use timestamp `20260424000000` or current; format matches existing migrations).
+
+```sql
+-- Add path_variables column to requests
+ALTER TABLE requests
+  ADD COLUMN IF NOT EXISTS path_variables JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN requests.path_variables IS
+  'Path variables declared inline in url via :name syntax. Array of {key, value}, order matches URL order.';
+```
+
+No RLS changes — column inherits row-level policies from the existing `requests` table.
+
+### Data layer (`src/data/supabase/requests.js`)
+Mirror the existing `params` pattern.
+
+In `parseRequest`, add:
+```js
+path_variables: typeof request.path_variables === 'string'
+  ? JSON.parse(request.path_variables || '[]')
+  : (request.path_variables || []),
+```
+
+In `createRequest`'s insert payload, add:
+```js
+path_variables: request.path_variables ? JSON.stringify(request.path_variables) : '[]',
+```
+
+In `updateRequest`, add:
+```js
+if (updates.path_variables !== undefined) {
+  updateData.path_variables = JSON.stringify(updates.path_variables);
+}
+```
+
+Stored shape: `[{ "key": "id", "value": "42" }, ...]`. Order matters (mirrors URL order). No `enabled` flag — presence in array means active (per issue spec).
+
+### Shared substitution util (NEW: `src/utils/substituteVariables.js`)
+
+Replaces the three duplicated substitution functions. Single source of truth.
+
+```js
+// src/utils/substituteVariables.js
+
+/**
+ * Build the merged variable map (collection lower priority, env higher).
+ * Returns a Map<string, string> ready for substitution.
+ *
+ * Single-pass merge avoids the bug where iterating two lists sequentially
+ * means the second list can't override because the first already replaced
+ * the {{key}} pattern.
+ */
+function buildEnvMap({ environment, collectionVariables }) {
+  const resolved = new Map();
+  if (collectionVariables) {
+    for (const v of collectionVariables) {
+      if (v.enabled === false || !v.key) continue;
+      resolved.set(v.key, v.value ?? v.current_value ?? v.initial_value ?? '');
+    }
+  }
+  if (environment?.variables) {
+    for (const v of environment.variables) {
+      if (v.enabled === false || !v.key) continue;
+      resolved.set(v.key, v.value ?? v.current_value ?? v.initial_value ?? '');
+    }
+  }
+  return resolved;
+}
+
+function applyEnvSubstitution(text, envMap) {
+  if (!text) return text;
+  let result = text;
+  for (const [key, value] of envMap) {
+    result = result.replace(new RegExp(`\\{\\{\\s*${escapeRegex(key)}\\s*\\}\\}`, 'g'), value);
+  }
+  return result;
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Substitute {{env}} and {{collection}} variables in arbitrary text.
+ * Used for headers, body, auth, form-data, query params.
+ */
+export function substituteEnv(text, { environment, collectionVariables } = {}) {
+  if (!text) return text;
+  return applyEnvSubstitution(text, buildEnvMap({ environment, collectionVariables }));
+}
+
+/**
+ * Substitute the URL: applies path variables first (with their values
+ * env-resolved), THEN env substitution. This order matches the issue spec:
+ *   1. Resolve {{env}} inside each path-var value
+ *   2. Replace :name in URL
+ *   3. Apply {{env}} to remaining URL text
+ *
+ * pathVariables: Array<{ key, value }>
+ */
+export function substituteUrl(url, { environment, collectionVariables, pathVariables } = {}) {
+  if (!url) return url;
+  const envMap = buildEnvMap({ environment, collectionVariables });
+
+  let result = url;
+  if (pathVariables && pathVariables.length > 0) {
+    for (const pv of pathVariables) {
+      if (!pv.key) continue;
+      const resolvedValue = applyEnvSubstitution(pv.value || '', envMap);
+      // Match :key as a token: must not be followed by another path-var-name char.
+      // Allowed name chars: anything not in the reserved set (see PATH_VAR_RESERVED).
+      // Use a negative lookahead so :foo does not greedily consume into :foobar.
+      // BUT path-var keys are already exact strings, so the safest approach is
+      // a word-boundary-ish regex: :KEY followed by end-of-string OR a reserved char.
+      const pattern = new RegExp(
+        `:${escapeRegex(pv.key)}(?=$|[/?#\\[\\]@!$&'()*+,;=\\s])`,
+        'g'
+      );
+      result = result.replace(pattern, resolvedValue);
+    }
+  }
+  // Then env substitution on whatever remains (e.g. {{baseUrl}} in the URL prefix).
+  result = applyEnvSubstitution(result, envMap);
+  return result;
+}
+
+/**
+ * Reserved characters that terminate a path variable name.
+ * RFC 3986 reserved chars + space + colon (a second colon ends the variable).
+ *
+ * NOTE: `.` is not reserved — `/api/v1.2/users/:id` is fine and `:id` will not
+ * try to absorb `.`. But `.` IS allowed inside a path-var name if the user types
+ * `:foo.bar` — the regex above terminates at reserved chars so `.bar` would be
+ * INSIDE the name, which is correct.
+ */
+export const PATH_VAR_RESERVED = new Set([
+  '/', '?', '#', '[', ']', '@',
+  '!', '$', '&', "'", '(', ')', '*', '+', ',', ';', '=',
+  ' ', ':',
+]);
+
+/**
+ * Parse :name tokens out of a URL string in order.
+ * Returns Array<{ key, start, end }> where start/end are character indexes.
+ *
+ * Key rules:
+ * - Starts at a `:` that is not preceded by `:` (to skip `::`).
+ * - Name is everything from after the `:` up to (but not including) the next
+ *   reserved character or end-of-string.
+ * - If the name is empty (i.e. `:` immediately followed by reserved char), it
+ *   is NOT a valid path variable. The caller is responsible for stripping the
+ *   stray `:` (see `sanitizeUrlForPathVars`).
+ * - Duplicate keys produce one entry each but reconcile() dedupes by first
+ *   occurrence (a path with `/users/:id/sub/:id` shows ONE row for `id`).
+ */
+export function extractPathVarTokens(url) {
+  if (!url) return [];
+  const tokens = [];
+  let i = 0;
+  while (i < url.length) {
+    const ch = url[i];
+    if (ch === ':' && url[i - 1] !== ':' && url[i + 1] !== ':') {
+      // Find name end
+      let j = i + 1;
+      while (j < url.length && !PATH_VAR_RESERVED.has(url[j])) j++;
+      if (j > i + 1) {
+        tokens.push({ key: url.slice(i + 1, j), start: i, end: j });
+        i = j;
+        continue;
+      }
+    }
+    i++;
+  }
+  return tokens;
+}
+
+/**
+ * Strip stray `:` characters that are followed immediately by a reserved char
+ * (or end-of-string). Per the issue spec: typing `/:/` should become `//`,
+ * `/:?` becomes `/?`, etc.
+ *
+ * Note: a trailing `:` at the very end of the URL is NOT stripped (the user
+ * may still be mid-typing the name). Reconciliation with the existing path-var
+ * list will simply not produce a row for it yet.
+ */
+export function sanitizeUrlForPathVars(url) {
+  if (!url) return url;
+  let result = '';
+  for (let i = 0; i < url.length; i++) {
+    const ch = url[i];
+    if (ch === ':') {
+      const next = url[i + 1];
+      // Strip if next char is a reserved char (NOT end-of-string — let the user keep typing)
+      if (next !== undefined && PATH_VAR_RESERVED.has(next) && next !== ':') {
+        // skip this colon
+        continue;
+      }
+    }
+    result += ch;
+  }
+  return result;
+}
+
+/**
+ * Reconcile current path-variables list against the URL.
+ * - For every token in the URL: if a key already exists in the list, keep its value.
+ * - For every key in the list NOT in the URL: drop it.
+ * - New keys appended in URL order with empty value.
+ * - Duplicate keys in URL produce a single row (first occurrence wins).
+ *
+ * Pure function. Returns a new array.
+ */
+export function reconcilePathVariables(url, currentPathVars) {
+  const tokens = extractPathVarTokens(url);
+  const seen = new Set();
+  const result = [];
+  for (const t of tokens) {
+    if (seen.has(t.key)) continue;
+    seen.add(t.key);
+    const existing = currentPathVars?.find(pv => pv.key === t.key);
+    result.push({ key: t.key, value: existing?.value || '' });
+  }
+  return result;
+}
+```
+
+### Refactor existing call sites
+
+**`src/hooks/useResponseExecution.js`** — replace lines 173–209 (`substituteWithEnv` block).
+
+```js
+import { substituteEnv, substituteUrl } from '../utils/substituteVariables';
+
+// Caller already destructures pathVariables from the active tab/request:
+const pathVariables = ...; // wired from RequestEditor save payload (F2)
+
+const subEnv = (text) => substituteEnv(text, { environment: currentEnv, collectionVariables: collectionVars });
+const resolvedUrl = substituteUrl(url, { environment: currentEnv, collectionVariables: collectionVars, pathVariables });
+
+const resolvedHeaders = headers.map(h => ({ ...h, key: subEnv(h.key), value: subEnv(h.value) }));
+const resolvedBody = subEnv(body);
+const resolvedAuthToken = subEnv(authToken);
+const resolvedFormData = formData?.map(f => ({
+  ...f,
+  key: subEnv(f.key),
+  value: f.type === 'file' ? f.value : subEnv(f.value),
+}));
+```
+
+`handleSendRequest` signature gains `pathVariables` parameter (default `[]`). Caller in `RequestEditor.jsx` passes the array on Send.
+
+**`src/hooks/useWorkflowExecution.js`** — replace lines 138–155 (`substitute` block).
+
+Workflow steps load each request fresh from DB (or use the dirty tab's data). Read `request.path_variables` for each step:
+
+```js
+import { substituteEnv, substituteUrl } from '../utils/substituteVariables';
+
+const subEnv = (text) => substituteEnv(text, { environment: currentEnv, collectionVariables: collectionVars });
+const resolvedUrl = substituteUrl(request.url, {
+  environment: currentEnv,
+  collectionVariables: collectionVars,
+  pathVariables: request.path_variables || [],
+});
+```
+
+This also fixes the pre-existing bug where the workflow's substitute() iterates collection then env separately, so env can never override a collection key with the same name. The shared util uses the merged-map pattern.
+
+**`src/components/CurlPanel.jsx`** — replace lines 109–145 (`sub` block).
+
+```js
+import { substituteEnv, substituteUrl } from '../utils/substituteVariables';
+
+const env = { environment: activeEnvironment, collectionVariables };
+const sub = (text) => substituteEnv(text, env);
+const subUrl = (url) => substituteUrl(url, { ...env, pathVariables: req.path_variables || [] });
+
+// ...
+return generateCurl(
+  req.method || 'GET',
+  subUrl(req.url || ''),
+  headers,
+  sub(req.body || ''),
+  req.body_type || 'none',
+  fd,
+  authType,
+  sub(authToken)
+);
+```
+
+`activeTab.request` (the dirty editor state, when present) carries `path_variables` on every change so the cURL preview updates live as the user types `:id` and edits the value.
+
+### F1 Acceptance Criteria
+
+**AC-F1.1 — Migration applies cleanly**
+- After `supabase db reset` (or `supabase migration up`), `requests` table has a `path_variables JSONB DEFAULT '[]'` column.
+- Existing rows have `path_variables = []`.
+
+**AC-F1.2 — Data layer round-trips path_variables**
+- `createRequest({ path_variables: [{key:'id', value:'42'}] })` then `getRequest(id)` returns `path_variables` as `[{key:'id', value:'42'}]` (array, not string).
+- `updateRequest(id, { path_variables: [...] })` persists.
+- `updateRequest(id, {})` (no path_variables key) does NOT clobber the existing value.
+
+**AC-F1.3 — substituteUrl applies path-vars before env**
+- Given `url = '/users/:id'`, `pathVariables = [{key:'id', value:'42'}]`, no env: result = `/users/42`.
+- Given `url = '/users/:id'`, `pathVariables = [{key:'id', value:'{{user_id}}'}]`, env `user_id = 42`: result = `/users/42`.
+- Given `url = '{{baseUrl}}/users/:id'`, `pathVariables = [{key:'id', value:'42'}]`, env `baseUrl = 'https://api.example.com'`: result = `https://api.example.com/users/42`.
+
+**AC-F1.4 — Path-var name regex respects reserved chars**
+- `url = '/users/:id/posts'`, `pathVariables = [{key:'id', value:'42'}]` → `/users/42/posts` (the `/` after `:id` correctly terminates the name match).
+- `url = '/users/:id'` (end-of-string) with `pathVariables = [{key:'id', value:'42'}]` → `/users/42`.
+- `url = '/users/:id?x=1'` → `/users/42?x=1`.
+
+**AC-F1.5 — Path-var matches don't bleed across names**
+- `url = '/api/:foo/:foobar'`, `pathVariables = [{key:'foo', value:'A'}, {key:'foobar', value:'B'}]` → `/api/A/B` (NOT `/api/A/Abar`). The `(?=$|[reserved])` lookahead prevents `:foo` from matching `:foobar`'s prefix.
+
+**AC-F1.6 — substituteEnv unchanged behavior**
+- `substituteEnv('hello {{name}}', { environment: { variables: [{ key:'name', value:'world', enabled:true }] } })` = `'hello world'`.
+- All existing E2E tests that exercise env / collection substitution continue to pass.
+
+**AC-F1.7 — Workflow execution bug fix (free side benefit)**
+- Given collection var `host = 'old.example.com'` and env var `host = 'new.example.com'` (env active), workflow request URL `https://{{host}}/users` now resolves to `https://new.example.com/users` (env wins). Before the refactor it resolved to `https://old.example.com/users` due to sequential-replacement bug.
+
+**AC-F1.8 — Pure unit-style smoke test**
+- Add `e2e/path-variables.spec.ts` that imports `substituteUrl` directly via Vite test runner OR uses Playwright `page.evaluate` to invoke it through the frontend bundle. Smoke-test the four cases above.
+- (We don't have Vitest configured. Prefer adding the smoke as a Playwright test that triggers a Send and asserts on the resolved URL log line in the request console — see `useResponseExecution.js:254` `Resolved URL: ${resolvedUrl}` log.)
+
+---
+
+## F2 — URL Parsing and Path Variables Section
+
+### `RequestEditor.jsx` state additions
+
+After the existing `params` useState (around line 130):
+
+```js
+const [pathVariables, setPathVariables] = useState([]);
+```
+
+In the initialization effect (alongside `setParams(initializeParams(...))` around line 187 / 206):
+
+```js
+const initialPathVars = reqData.path_variables || request?.path_variables || [];
+const reconciledPathVars = reconcilePathVariables(reqData.url || request?.url || '', initialPathVars);
+setPathVariables(reconciledPathVars);
+```
+
+### URL change handler
+
+Modify `handleUrlChange` (around line 232–252). After `setUrl(newUrl)`:
+
+```js
+const handleUrlChange = (rawUrl) => {
+  // Strip stray `:` followed by reserved chars (e.g. typing `/:/` collapses to `//`)
+  const sanitized = sanitizeUrlForPathVars(rawUrl);
+
+  setUrl(sanitized);
+
+  // Sync params from URL while preserving disabled params (existing logic, unchanged)
+  const urlParams = parseUrlParams(sanitized);
+  const disabledParams = params.filter(p => !p.enabled && p.key.trim());
+  const mergedParams = [
+    ...urlParams.filter(p => p.key.trim()),
+    ...disabledParams,
+  ];
+  if (mergedParams.length === 0 || mergedParams[mergedParams.length - 1].key !== '') {
+    mergedParams.push({ key: '', value: '', enabled: true });
+  }
+  setParams(mergedParams);
+
+  // NEW: reconcile path vars
+  const newPathVars = reconcilePathVariables(sanitized, pathVariables);
+  setPathVariables(newPathVars);
+
+  notifyChange({ url: sanitized, params: mergedParams, path_variables: newPathVars });
+};
+```
+
+**Caret handling on sanitization:** if the user types `:` then immediately `/`, the `:` is removed from the sanitized URL. The native input's caret position will normally end up after the removed `:` — i.e. it stays at what is now the position right after the `/`. That matches what the user expects (typed two chars, second char "absorbed" the first). DO NOT manually setSelectionRange to override; the browser handles this fine. If Agent B observes flicker, defer caret correction to a `requestAnimationFrame`.
+
+### Path Variables section UI
+
+Inside the existing `activeDetailTab === 'params'` block (around line 620), AFTER the closing `</table>` of the params table:
+
+```jsx
+{pathVariables.length > 0 && (
+  <div className="path-variables-section" data-testid="path-variables-section">
+    <div className="path-variables-header">
+      <span className="path-variables-title">Path Variables</span>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: '30px' }}></th>
+          <th>Key</th>
+          <th>Value</th>
+          <th style={{ width: '40px' }}></th>
+        </tr>
+      </thead>
+      <tbody>
+        {pathVariables.map((pv) => (
+          <tr key={pv.key} data-testid={`path-variable-row-${pv.key}`}>
+            <td></td>
+            <td>
+              <input
+                type="text"
+                className="path-var-key-readonly"
+                value={pv.key}
+                readOnly
+                tabIndex={-1}
+                data-testid={`path-variable-key-${pv.key}`}
+                title="Edit the URL above to change this key"
+              />
+            </td>
+            <td>
+              <EnvVariableInput
+                value={pv.value}
+                onChange={(e) => {
+                  const updated = pathVariables.map(p =>
+                    p.key === pv.key ? { ...p, value: e.target.value } : p
+                  );
+                  setPathVariables(updated);
+                  notifyChange({ path_variables: updated });
+                }}
+                placeholder="Value"
+                activeEnvironment={activeEnvironment}
+                collectionVariables={collectionVariables}
+                rootCollectionId={rootCollectionId}
+                onEnvironmentUpdate={onEnvironmentUpdate}
+                data-testid={`path-variable-value-input-${pv.key}`}
+              />
+            </td>
+            <td>{/* no delete button — deletion via URL editing */}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)}
+```
+
+CSS (`src/styles/request-editor.css`, append):
+
+```css
+.path-variables-section {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px dashed var(--border-secondary);
+}
+
+.path-variables-header {
+  padding: 0 var(--space-3) var(--space-2);
+}
+
+.path-variables-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+}
+
+.path-var-key-readonly {
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: default;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  width: 100%;
+  padding: var(--space-2);
+}
+
+.path-var-key-readonly:focus {
+  outline: none;
+  border-color: var(--border-primary);
+  background: var(--bg-input);
+}
+```
+
+### Save persistence
+
+Modify `handleSave` (around line 376–411). The `paramsToSave` block already filters params; after it, add:
+
+```js
+// Path variables: save as-is (already reconciled to URL on every keystroke).
+// Trim values' {{var}} whitespace consistently with other vars.
+const pathVarsToSave = pathVariables.map(pv => ({ ...pv, value: trimVars(pv.value) }));
+```
+
+Pass `path_variables: pathVarsToSave` in both `data.createRequest` and `data.updateRequest` payloads.
+
+For example save (line ~411 area), include `path_variables: pathVarsToSave` likewise in `request_data`.
+
+For the temporary-save path (around line 420), include `path_variables: pathVarsToSave`.
+
+### Send request wires path_variables
+
+In `handleSend` (early in the file, before line ~371): pass `pathVariables` into `onSend` payload.
+
+```js
+onSend({
+  // ...existing fields
+  pathVariables, // NEW
+});
+```
+
+`useResponseExecution.handleSendRequest` accepts `pathVariables`, defaults `[]`, threads into `substituteUrl`.
+
+The `Try` button (example mode, line ~503) also needs `pathVariables: example?.request_data?.path_variables || []`.
+
+### `notifyChange` and `dirty` tracking
+
+The existing `notifyChange` already accepts arbitrary fields and bubbles up. Add `path_variables` to the dirty-detection equality check (find where `params` is compared and mirror the same logic). Probably in `WorkbenchContext` or wherever `originalRequestsRef` is consulted.
+
+### F2 Acceptance Criteria
+
+**AC-F2.1 — Typing `:name` adds a row**
+- URL field empty. Type `/users/:id`. After the keystroke that produces `d`, `[data-testid="path-variables-section"]` is visible and contains one row `[data-testid="path-variable-row-id"]` with key text `id` and empty value.
+
+**AC-F2.2 — Typing `:` alone shows nothing**
+- URL `/users/:`. No row. Section hidden (length 0).
+
+**AC-F2.3 — Multiple path vars in URL order**
+- URL `/users/:id/posts/:postId`. Two rows, in order `id` then `postId`.
+
+**AC-F2.4 — Reserved char strips the `:`**
+- URL field has `/users/`. Type `:` then `/` immediately. Final URL is `/users//`. No path-var row.
+- Same with `:?`, `:#`, `:&`, `:=`, `: ` (space) — the `:` is stripped on commit.
+
+**AC-F2.5 — Trailing `:` at end-of-string is preserved**
+- URL `/users/:`. The `:` stays in the input (user is still typing). No row yet.
+- Continue typing `id` → URL becomes `/users/:id` and the row appears.
+
+**AC-F2.6 — Removing `:name` from URL removes the row**
+- URL `/users/:id`. Backspace 3 times to leave `/users/`. The row disappears.
+
+**AC-F2.7 — Renaming `:name` preserves value when char-adjacent**
+- URL `/users/:id`, value set to `42`. Edit URL to `/users/:idx`. The old row `id` is gone, a new row `idx` exists with value `''`. (Renaming is an add+remove, NOT a rename — value does not migrate. This matches Postman.)
+
+**AC-F2.8 — Editing key in the list is impossible**
+- The `[data-testid="path-variable-key-{name}"]` input has the `readOnly` attribute. Attempting to type into it does not change its value.
+
+**AC-F2.9 — Editing value in the list works**
+- Click `[data-testid="path-variable-value-input-id"]` (it's an `EnvVariableInput`'s wrapped input). Type `42`. Value is `42`. Save the request.
+
+**AC-F2.10 — Path variables persist across reload**
+- Save a request with URL `/users/:id` and value `42`. Reload the page. Open the request. URL `/users/:id`, path-var row shows `id = 42`.
+
+**AC-F2.11 — Send substitutes path var**
+- Request URL `/post`, body `{}`, path-var-section absent. Send → request goes to `/post` (regression check).
+- Change URL to `/post/:id`, set value `42`. Send → request goes to `/post/42`. The console log shows `Resolved URL: <full-url>/post/42`.
+
+**AC-F2.12 — Path-var value can reference env var**
+- Env active with `user_id = 99`. Request URL `/users/:id`, path-var value `{{user_id}}`. Send → resolved URL contains `/users/99`.
+
+**AC-F2.13 — cURL preview matches**
+- Open cURL panel for the request from AC-F2.12. Preview shows `curl ... '/users/99' ...`. Editing the value to `100` updates the preview live.
+
+**AC-F2.14 — Duplicate `:name` in URL → single row**
+- URL `/a/:id/b/:id`. Path Variables section has exactly ONE row for `id`. Setting value `42` resolves both occurrences: send → `/a/42/b/42`.
+
+**AC-F2.15 — Section hidden when no path vars**
+- URL `/api/users`. `[data-testid="path-variables-section"]` is NOT in the DOM (or has zero count).
+
+**AC-F2.16 — Query params still work alongside path vars**
+- URL `/users/:id?active=true`. Path Variables row `id`. Params row `active=true`. Both edit independently. Send substitutes `:id`, leaves `?active=true` alone.
+
+---
+
+## F3 — URL Overlay Highlight + Popover
+
+### `EnvVariableInput.jsx` extension
+
+Add an optional `pathVariables` prop. When provided AND non-empty, the overlay also recognizes `:name` tokens.
+
+State changes: none. Prop addition only.
+
+```js
+export function EnvVariableInput({
+  value, onChange, onKeyDown, onPaste, placeholder, className,
+  activeEnvironment, collectionVariables, rootCollectionId, onEnvironmentUpdate,
+  pathVariables, // NEW — optional. Only the URL field passes this.
+  disabled = false,
+}) {
+```
+
+Update `hasVariables` (line 70):
+
+```js
+const hasVariables = /\{\{[^}]+\}\}/.test(value) || (pathVariables?.length > 0 && /:/.test(value));
+```
+
+Update `findVariableAtPosition` (line 29) to also detect `:name`:
+
+```js
+const findVariableAtPosition = (text, pos) => {
+  // First check {{var}} (existing)
+  const envRegex = /\{\{([^}]+)\}\}/g;
+  let match;
+  while ((match = envRegex.exec(text)) !== null) {
+    const start = match.index;
+    const end = match.index + match[0].length;
+    if (pos >= start && pos <= end) {
+      return { kind: 'env', name: match[1].trim(), start, end, fullMatch: match[0] };
+    }
+  }
+  // Then check :name path vars (only if pathVariables prop supplied)
+  if (pathVariables && pathVariables.length > 0) {
+    const tokens = extractPathVarTokens(text); // import from substituteVariables.js
+    for (const t of tokens) {
+      if (pos >= t.start && pos <= t.end) {
+        return { kind: 'path', name: t.key, start: t.start, end: t.end, fullMatch: text.slice(t.start, t.end) };
+      }
+    }
+  }
+  return null;
+};
+```
+
+Update `renderHighlightedText` (line 254) to also style `:name` tokens. Easiest: split the text into segments using a combined regex.
+
+```js
+const renderHighlightedText = () => {
+  if (!value) return null;
+  const segments = [];
+  let cursor = 0;
+
+  // Build a list of all token spans (env + path)
+  const tokens = [];
+  const envRegex = /\{\{[^}]+\}\}/g;
+  let m;
+  while ((m = envRegex.exec(value)) !== null) {
+    tokens.push({ start: m.index, end: m.index + m[0].length, kind: 'env', text: m[0] });
+  }
+  if (pathVariables && pathVariables.length > 0) {
+    for (const t of extractPathVarTokens(value)) {
+      tokens.push({ start: t.start, end: t.end, kind: 'path', text: value.slice(t.start, t.end), name: t.key });
+    }
+  }
+  tokens.sort((a, b) => a.start - b.start);
+
+  for (const tok of tokens) {
+    if (tok.start > cursor) segments.push({ text: value.slice(cursor, tok.start), isVar: false });
+    segments.push({ text: tok.text, isVar: true, kind: tok.kind, name: tok.name });
+    cursor = tok.end;
+  }
+  if (cursor < value.length) segments.push({ text: value.slice(cursor), isVar: false });
+
+  return segments.map((seg, i) => {
+    if (!seg.isVar) return <span key={i}>{seg.text}</span>;
+    if (seg.kind === 'env') {
+      const varName = seg.text.slice(2, -2).trim();
+      const source = getVariableSource(varName);
+      let varClass;
+      if (!source && !activeEnvironment) varClass = 'no-env';
+      else if (!source) varClass = 'unresolved';
+      else if (source === 'collection') varClass = 'collection';
+      else varClass = 'resolved';
+      return <span key={i} className={`env-var-highlight ${varClass}`}>{seg.text}</span>;
+    }
+    // kind === 'path'
+    const pv = pathVariables.find(p => p.key === seg.name);
+    const varClass = pv?.value ? 'path-resolved' : 'path-unresolved';
+    return <span key={i} className={`env-var-highlight ${varClass}`}>{seg.text}</span>;
+  });
+};
+```
+
+CSS (append to whichever stylesheet hosts `.env-var-highlight`):
+
+```css
+.env-var-highlight.path-resolved {
+  background: color-mix(in srgb, var(--accent-success) 20%, transparent);
+  color: var(--accent-success);
+}
+
+.env-var-highlight.path-unresolved {
+  background: color-mix(in srgb, var(--accent-warning) 20%, transparent);
+  color: var(--accent-warning);
+  text-decoration: underline dotted;
+}
+```
+
+If `color-mix` / `--accent-success` aren't available, fall back to `rgba(34, 197, 94, 0.2)` / `#22c55e`.
+
+### `RequestEditor.jsx` URL input wires pathVariables prop
+
+Modify the URL `EnvVariableInput` (line 490–502) to pass `pathVariables`:
+
+```jsx
+<EnvVariableInput
+  className="url-input"
+  // ...existing props
+  pathVariables={pathVariables} // NEW
+/>
+```
+
+The query-params value cells, headers, body, auth — **DO NOT** pass `pathVariables`. Path vars only render in the URL field.
+
+### Hover popover wiring
+
+`EnvVariableInput.handleMouseMove` (line 287) already calls `variablePopover.show({ varName, rect })`. For path vars, we need a separate path-var popover state.
+
+Easiest approach — extend the existing `VariablePopover` to accept a `kind` parameter. Augment its `show()` API:
+
+```js
+// VariablePopover.jsx — show()
+const show = useCallback(({ varName, rect, kind = 'env', pathVariables, onPathVarChange }) => {
+  if (isEditing) { clearHideTimeout(); return; }
+  // ... existing selection guard
+  clearHideTimeout();
+  if (kind === 'path') {
+    const pv = pathVariables?.find(p => p.key === varName);
+    setState({ varName, rect, kind: 'path', source: 'path', value: pv?.value || '', onPathVarChange });
+    setEditValue(pv?.value || '');
+  } else {
+    const source = getVariableSource(varName);
+    const value = getVariableValue(varName);
+    setState({ varName, rect, kind: 'env', source, value });
+    setEditValue(value || '');
+  }
+}, [isEditing, getVariableSource, getVariableValue, clearHideTimeout]);
+```
+
+`saveVariable()` adds a path-var branch:
+
+```js
+if (state.kind === 'path' && state.onPathVarChange) {
+  state.onPathVarChange(state.varName, valueToSave);
+  setIsEditing(false);
+  setState(null);
+  return;
+}
+// ...existing env/collection branches
+```
+
+`EnvVariableInput.handleMouseMove` checks the variable kind:
+
+```js
+const variable = findVariableAtPosition(value, charPos);
+if (variable) {
+  // ... existing rect math
+  if (variable.kind === 'path') {
+    variablePopover.show({
+      varName: variable.name,
+      rect: { ... },
+      kind: 'path',
+      pathVariables,
+      onPathVarChange: (key, newValue) => {
+        // Synthesize an onChange-like update by calling parent through a new prop:
+        onPathVariableValueChange?.(key, newValue);
+      },
+    });
+  } else {
+    variablePopover.show({ varName: variable.name, rect: {...} });
+  }
+}
+```
+
+This adds `onPathVariableValueChange` as a new prop on `EnvVariableInput`, called only when a path-var hover popover edits a value. `RequestEditor` provides:
+
+```jsx
+<EnvVariableInput
+  // ...
+  pathVariables={pathVariables}
+  onPathVariableValueChange={(key, newValue) => {
+    const updated = pathVariables.map(p => p.key === key ? { ...p, value: newValue } : p);
+    setPathVariables(updated);
+    notifyChange({ path_variables: updated });
+  }}
+/>
+```
+
+Header rendering in the popover for path-var kind:
+
+```js
+{state.kind === 'path' && (
+  <span className="env-var-name path">
+    <span className="suggestion-source-badge path">P</span>
+    {state.varName}
+  </span>
+)}
+```
+
+CSS for `.suggestion-source-badge.path` (matches existing env/collection badges):
+
+```css
+.suggestion-source-badge.path {
+  background: var(--accent-success);
+  color: white;
+}
+```
+
+### F3 Acceptance Criteria
+
+**AC-F3.1 — `:name` highlighted in URL input only**
+- URL `/users/:id`. Visible `<span class="env-var-highlight path-resolved">` (or `path-unresolved` if value is empty) wrapping `:id` in the URL input overlay.
+- Header value `:id`, body `:id`, query-param value `:id` — NO highlighting (the wrapping `EnvVariableInput`s don't pass `pathVariables`).
+
+**AC-F3.2 — Path-var color distinct from env**
+- `:id` shows green-ish accent. `{{token}}` shows blue accent. Visually distinguishable.
+
+**AC-F3.3 — Hover opens popover**
+- Hover `:id` in the URL input. Popover appears showing key `id`, source `Path`, current value, and "Click to edit" hint.
+
+**AC-F3.4 — Click-to-edit changes value**
+- Click the popover. Input field appears with current value. Type new value. Press Enter. Path Variables row reflects the new value.
+
+**AC-F3.5 — Path-var name doesn't bleed**
+- URL `/api/:foo/:foobar`. Hovering `:foo` opens popover for `foo` (NOT `foobar`). Hovering `:foobar` opens popover for `foobar`.
+
+**AC-F3.6 — `{{var}}` popover still works**
+- Hovering `{{baseUrl}}` in the URL still opens the env popover with the env value (regression check).
+
+---
+
+## Test Plan
+
+### NEW: `e2e/path-variables.spec.ts`
+
+Reuse `e2e/helpers/auth.ts` and the standard request-creation pattern from existing specs.
+
+Test fixture: a public echo endpoint where the resolved path is reflected in the response body (so we can assert the substitution happened). `httpbin.org/anything/<path>` reflects the path in the JSON response under `url`.
+
+1. **`f1-pure-substitute-url`** — Send request to `https://httpbin.org/anything/:id`, set path-var `id=42`. Assert response body's `url` field contains `/anything/42`.
+2. **`f1-path-var-with-env-interp`** — Env active with `user_id=99`. URL `/anything/:id`, value `{{user_id}}`. Send. Response `url` contains `/anything/99`.
+3. **`f2-typing-colon-adds-row`** — Open new request. Type `/anything/:id` in URL. Assert `[data-testid="path-variables-section"]` visible; row `path-variable-row-id` present.
+4. **`f2-typing-just-colon-no-row`** — URL `/users/:`. Section NOT in DOM.
+5. **`f2-multiple-path-vars-ordered`** — URL `/users/:userId/posts/:postId`. Two rows, in DOM order userId then postId.
+6. **`f2-reserved-char-strips-colon`** — Set URL to `/users/`. Send keystrokes `:` then `/`. Assert URL value is now `/users//` and no row exists.
+7. **`f2-trailing-colon-preserved`** — Set URL to `/users/`. Type `:`. URL is `/users/:`. No row. Type `i` then `d`. Now URL is `/users/:id` and row exists.
+8. **`f2-removing-name-removes-row`** — Set URL to `/users/:id` (row exists). Use Playwright keyboard to backspace 3 chars. URL `/users/`, row gone.
+9. **`f2-key-readonly`** — Path-var key input has `readOnly` attribute. Type into it; value unchanged.
+10. **`f2-value-edit-in-list`** — Set URL to `/anything/:id`. In the list, type `42` into value cell. Save. Reload. Open request. Path-var value still `42`.
+11. **`f2-persistence-across-reload`** — Create request, set URL `/anything/:id`, value `7`. Save. Reload page. Open request. URL still has `:id`, value still `7`. Send → response URL contains `/anything/7`.
+12. **`f2-curl-preview-matches`** — Same request as #11 but inspect cURL panel. Assert preview contains `'https://httpbin.org/anything/7'` (or however the URL is built).
+13. **`f2-duplicate-name-single-row`** — URL `/a/:id/b/:id`. One row for `id`. Set value `X`. Send → response URL contains `/a/X/b/X`.
+14. **`f2-section-hidden-when-no-path-vars`** — URL `/users`. Section not in DOM.
+15. **`f3-overlay-highlight-on-url`** — URL `/users/:id`. Inspect the URL input's overlay; assert a `.env-var-highlight.path-resolved` (or `path-unresolved`) span exists wrapping `:id`.
+16. **`f3-overlay-no-highlight-in-headers`** — Add a header value `:id`. Inspect headers value cell. NO `.env-var-highlight.path-*` span.
+17. **`f3-popover-opens-on-hover`** — URL `/users/:id`, value `42`. Hover the `:id` in the URL. Assert popover visible with text `id` and value `42`.
+18. **`f3-popover-edits-value`** — Hover `:id`. Click popover. Type `99`, press Enter. Path Variables row value is now `99`.
+19. **`f3-prefix-not-confused`** — URL `/api/:foo/:foobar`, both with values. Hover `:foo`. Popover shows `foo`. Hover `:foobar`. Popover shows `foobar`.
+
+### Regression — existing specs continue to pass
+
+- `e2e/environment.spec.ts` — env substitution still works.
+- `e2e/collection-variables.spec.ts` — collection substitution still works.
+- `e2e/request-editor.spec.ts` — params, headers, body, send still work.
+- `e2e/curl-preview.spec.ts` (if it exists) — cURL still renders.
+- `e2e/workflow.spec.ts` — workflows still execute. (Bonus: AC-F1.7 fixes a subtle pre-existing override bug; existing tests don't catch it but newly written ones should.)
+
+### Implementation order
+
+1. **F1** — migration, data layer, shared util, refactor three call sites. Run all existing E2E to confirm green.
+2. **F2** — RequestEditor parsing + Path Variables section + save persistence. Add F2 E2E tests.
+3. **F3** — overlay highlight + popover wiring. Add F3 E2E tests.
+
+Each phase ships green before moving on.
+
+## Risks & Notes
+
+- **Caret jumping after sanitization.** When `sanitizeUrlForPathVars` removes a `:`, the input `value` shrinks by 1 char. React re-renders; the browser preserves caret position relative to the start, which lands the caret in the right place (right after the absorbed character). Verified in browser; if Agent B sees flicker, defer caret correction to `requestAnimationFrame` and `setSelectionRange` to the position where the typed char would have landed (cursor was at `oldPos + 1`, sanitization removed 1 char before cursor, so new pos = `oldPos + 1 - 1 = oldPos`).
+
+- **Substitution regex character class for path-var name termination.** The `(?=$|[/?#\[\]@!$&'()*+,;=\s])` lookahead in `substituteUrl` MUST mirror `PATH_VAR_RESERVED` exactly. If they drift, `:foo.bar` (which is valid — no reserved char) might fail to substitute correctly. Single source of truth: `PATH_VAR_RESERVED` Set; build the lookahead from it programmatically OR keep them lockstep with a comment.
+
+- **Path-var name with regex meta chars.** `escapeRegex(pv.key)` in `substituteUrl` handles this (a user couldn't legitimately enter `[` since it's reserved, but defensive escape is cheap).
+
+- **`workflows` table doesn't replicate path_variables.** Workflow steps are request-ID references, so they look up `request.path_variables` from the DB at execution time. No data duplication needed. Confirmed in `useWorkflowExecution.js:138` style.
+
+- **Postman compatibility on import.** Postman's collection v2.1 stores path variables in `request.url.variable[]`. NOT included in this PR — `import-postman` E2E test already passes; we just won't extract path vars yet. Follow-up issue worth filing after this lands.
+
+- **`:` in the host portion of the URL.** Many users type `https://localhost:3000/api/:id`. Our parser currently treats `:3000` as a path-var named `3000` — clearly wrong. Mitigation: the `extractPathVarTokens` parser must skip `:` that appears between `://` and the first `/`. Add this guard:
+  ```js
+  // Skip the scheme://host:port section
+  let pathStart = 0;
+  const schemeMatch = url.match(/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//);
+  if (schemeMatch) {
+    const afterScheme = schemeMatch[0].length;
+    const firstSlash = url.indexOf('/', afterScheme);
+    pathStart = firstSlash === -1 ? url.length : firstSlash;
+  }
+  // Then iterate from pathStart instead of 0.
+  ```
+  Test fixture: URL `https://localhost:3000/api/:id` → `extractPathVarTokens` returns ONE token `id`, NOT `3000`.
+
+  This is critical and must be in F1 from day one. Add an explicit acceptance test:
+
+  **AC-F1.9 — Port number in URL is not treated as path-var**
+  - `extractPathVarTokens('https://localhost:3000/api/:id')` returns exactly `[{ key: 'id', start: 27, end: 30 }]`.
+  - `substituteUrl('https://localhost:3000/api/:id', { pathVariables: [{key:'id', value:'42'}] })` returns `https://localhost:3000/api/42`.
+
+- **`:` in query string.** A user may have `?token=foo:bar` after the `?`. Following the same logic, `:` in the query-string portion shouldn't be parsed as a path var. Refine the parser to also stop at `?` and `#`:
+  ```js
+  // After computing pathStart, also compute pathEnd at the first ? or #
+  const queryStart = url.indexOf('?', pathStart);
+  const hashStart = url.indexOf('#', pathStart);
+  let pathEnd = url.length;
+  if (queryStart !== -1) pathEnd = Math.min(pathEnd, queryStart);
+  if (hashStart !== -1) pathEnd = Math.min(pathEnd, hashStart);
+  // Iterate i from pathStart to pathEnd.
+  ```
+
+  **AC-F1.10 — `:` in query string ignored**
+  - `extractPathVarTokens('/api/:id?ts=2024:01:01')` returns ONE token `id`. The `:01:01` in the query string is ignored.
+
+These two parser refinements (port and query) are non-negotiable for F1.

--- a/e2e/path-variables.spec.ts
+++ b/e2e/path-variables.spec.ts
@@ -1,0 +1,738 @@
+import { test, expect, Page } from '@playwright/test';
+import { cleanupTestCollections, cleanupTestEnvironments } from './helpers/cleanup';
+
+const timestamp = Date.now();
+const uniqueName = (base: string) => `${base} ${timestamp}`;
+
+test.afterAll(async () => {
+  await cleanupTestCollections(timestamp);
+  await cleanupTestEnvironments(timestamp);
+});
+
+async function waitForAppReady(page: Page) {
+  await page.goto('/');
+  await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 15000 });
+  await expect(page.locator('.workspace-selector-label')).not.toHaveText('Loading...', { timeout: 10000 });
+  await expect(page.locator('.workspace-selector-label')).not.toHaveText('No Workspace', { timeout: 10000 });
+  await expect(page.locator('.sidebar')).toBeVisible();
+  await expect(page.locator('.sidebar .loading-spinner')).not.toBeVisible({ timeout: 10000 });
+  await page.evaluate(() => {
+    const toast = document.querySelector('.version-toast');
+    if (toast) (toast as HTMLElement).style.display = 'none';
+  });
+}
+
+async function createCollection(page: Page, name: string) {
+  const addBtn = page.locator('.sidebar-toolbar .btn-icon').last();
+  await expect(addBtn).toBeEnabled({ timeout: 10000 });
+  await addBtn.click();
+
+  const promptModal = page.locator('.prompt-modal');
+  await expect(promptModal).toBeVisible({ timeout: 5000 });
+  await promptModal.locator('.prompt-input').fill(name);
+  await promptModal.locator('.prompt-btn-confirm').click();
+  await expect(promptModal).not.toBeVisible();
+
+  await expect(page.locator('.collection-header').filter({ hasText: name })).toBeVisible({ timeout: 5000 });
+}
+
+async function addRequestInCollection(page: Page, collectionName: string) {
+  const header = page.locator('.collection-header').filter({ hasText: collectionName });
+  await header.hover();
+  const moreBtn = header.locator('.btn-menu');
+  await expect(moreBtn).toBeVisible();
+  await moreBtn.click();
+
+  const menu = page.locator('.collection-menu');
+  await expect(menu).toBeVisible();
+  await menu.locator('.request-menu-item').filter({ hasText: 'Add Request' }).click();
+
+  await expect(page.locator('.request-editor')).toBeVisible({ timeout: 5000 });
+}
+
+async function createTestRequest(page: Page, collectionName: string) {
+  await createCollection(page, collectionName);
+  await addRequestInCollection(page, collectionName);
+}
+
+async function openParamsTab(page: Page) {
+  await page.locator('.request-tabs button').filter({ hasText: 'Params' }).click();
+}
+
+async function openHeadersTab(page: Page) {
+  await page.locator('.request-tabs button').filter({ hasText: 'Headers' }).click();
+}
+
+async function openConsolePanel(page: Page) {
+  const consoleBtn = page.locator('[data-testid="bottom-bar"]').locator('text=Console');
+  await expect(consoleBtn).toBeVisible({ timeout: 5000 });
+  const isAlreadyOpen = await page.locator('[data-testid="console-panel"]').isVisible().catch(() => false);
+  if (!isAlreadyOpen) {
+    await consoleBtn.click();
+    await expect(page.locator('[data-testid="console-panel"]')).toBeVisible({ timeout: 5000 });
+  }
+}
+
+async function clearConsole(page: Page) {
+  await openConsolePanel(page);
+  const clearBtn = page.locator('[data-testid="console-clear"]');
+  if (await clearBtn.isVisible().catch(() => false)) {
+    await clearBtn.click();
+  }
+}
+
+async function sendRequestAndWait(page: Page) {
+  const sendButton = page.locator('.btn-send');
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+  // Don't require .response-viewer to be visible — when the Console panel is open,
+  // it can shrink the viewer to ~0 height in the default Playwright viewport. Use the
+  // Send→Cancel→Send button transition as the completion signal instead.
+  await expect(page.locator('.btn-cancel-request')).toHaveCount(0, { timeout: 30000 });
+  await expect(sendButton).toBeEnabled({ timeout: 5000 });
+}
+
+async function getResolvedUrlFromConsole(page: Page): Promise<string | null> {
+  await openConsolePanel(page);
+  // Find any console-message containing "Resolved URL:"
+  const messages = page.locator('.console-panel-body .console-message');
+  const count = await messages.count();
+  for (let i = 0; i < count; i++) {
+    const text = (await messages.nth(i).textContent()) || '';
+    const match = text.match(/Resolved URL:\s*(.+)/);
+    if (match) return match[1].trim();
+  }
+  return null;
+}
+
+async function openCurlPanel(page: Page) {
+  const curlBtn = page.locator('.btn-copy-curl');
+  await expect(curlBtn).toBeVisible({ timeout: 5000 });
+  const className = (await curlBtn.getAttribute('class')) || '';
+  if (!className.includes('active')) {
+    await curlBtn.click();
+  }
+  await expect(page.locator('.curl-panel')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-testid="curl-panel-code"]')).toBeVisible({ timeout: 5000 });
+}
+
+async function readCurlText(page: Page): Promise<string> {
+  const code = page.locator('[data-testid="curl-panel-code"] .cm-content');
+  await expect(code).toBeVisible({ timeout: 5000 });
+  return (await code.innerText()).replace(/ /g, ' ');
+}
+
+async function openEnvironmentEditor(page: Page) {
+  const envSelector = page.locator('.env-selector-trigger');
+  await expect(envSelector).toBeVisible();
+  await envSelector.click();
+  const manageBtn = page.locator('.env-selector-edit');
+  await expect(manageBtn).toBeVisible();
+  await manageBtn.click();
+  const envDrawer = page.locator('.env-drawer');
+  await expect(envDrawer).toBeVisible({ timeout: 5000 });
+  return envDrawer;
+}
+
+async function createAndActivateEnvironment(page: Page, envName: string, key: string, value: string) {
+  const envDrawer = await openEnvironmentEditor(page);
+  const addBtn = envDrawer.locator('.env-list-header .btn-icon');
+  await addBtn.click();
+
+  const promptModal = page.locator('.prompt-modal');
+  await expect(promptModal).toBeVisible({ timeout: 5000 });
+  await promptModal.locator('.prompt-input').fill(envName);
+  await promptModal.locator('.prompt-btn-confirm').click();
+  await expect(promptModal).not.toBeVisible();
+
+  await expect(envDrawer.locator('.env-var-title')).toContainText(envName, { timeout: 5000 });
+
+  const addVarBtn = envDrawer.locator('.btn-add-var');
+  await addVarBtn.click();
+
+  const varTable = envDrawer.locator('.env-var-table table tbody');
+  const newRow = varTable.locator('tr').first();
+  await newRow.locator('input[placeholder="Variable name"]').fill(key);
+  await newRow.locator('input[placeholder="Value"]').fill(value);
+
+  const saveBtn = envDrawer.locator('.btn-save');
+  await expect(saveBtn).toBeEnabled({ timeout: 5000 });
+  await saveBtn.click();
+  await expect(saveBtn).toBeDisabled({ timeout: 10000 });
+  await page.waitForTimeout(300);
+
+  await envDrawer.locator('.env-drawer-header .btn-icon').click();
+  const confirmDialog = page.locator('.confirm-modal');
+  if (await confirmDialog.isVisible().catch(() => false)) {
+    await confirmDialog.locator('.confirm-btn-cancel').click().catch(() => {});
+  }
+  await expect(envDrawer).not.toBeVisible({ timeout: 5000 });
+
+  const envSelector = page.locator('.env-selector-trigger');
+  await envSelector.click();
+  const envDropdown = page.locator('.env-selector-dropdown');
+  await expect(envDropdown).toBeVisible();
+  await envDropdown.locator('.env-selector-option').filter({ hasText: envName }).click();
+  await expect(envSelector).toContainText(envName);
+  await expect(envSelector).toHaveClass(/has-env/);
+}
+
+async function saveRequest(page: Page) {
+  const saveBtn = page.locator('.btn-save').first();
+  await expect(saveBtn).toBeEnabled({ timeout: 5000 });
+  await saveBtn.click();
+  await expect(saveBtn).not.toContainText('*', { timeout: 5000 });
+}
+
+test.describe('Path Variables', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForAppReady(page);
+  });
+
+  // AC-F1.3, AC-F1.4, AC-F2.11
+  test('f1-pure-substitute-url', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F1 Pure'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/anything/:id');
+
+    await openParamsTab(page);
+    const section = page.locator('[data-testid="path-variables-section"]');
+    await expect(section).toBeVisible({ timeout: 5000 });
+
+    const valueInput = page.locator('[data-testid="path-variable-value-input-id"]');
+    await expect(valueInput).toBeVisible();
+    // EnvVariableInput wraps an actual <input>; target it with locator chain
+    const valueField = valueInput.locator('input').first();
+    await valueField.fill('42');
+
+    await clearConsole(page);
+    await sendRequestAndWait(page);
+
+    const resolved = await getResolvedUrlFromConsole(page);
+    expect(resolved).not.toBeNull();
+    expect(resolved!).toContain('/anything/42');
+    expect(resolved!).not.toContain(':id');
+  });
+
+  // AC-F1.3, AC-F2.12
+  test('f1-path-var-with-env-interp', async ({ page }) => {
+    const envName = uniqueName('PV Env');
+    await createAndActivateEnvironment(page, envName, 'user_id', '99');
+
+    await createTestRequest(page, uniqueName('PV F1 EnvInterp'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/anything/:id');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variables-section"]')).toBeVisible({ timeout: 5000 });
+
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await valueField.fill('{{user_id}}');
+
+    await clearConsole(page);
+    await sendRequestAndWait(page);
+
+    const resolved = await getResolvedUrlFromConsole(page);
+    expect(resolved).not.toBeNull();
+    expect(resolved!).toContain('/anything/99');
+    expect(resolved!).not.toContain('{{user_id}}');
+    expect(resolved!).not.toContain(':id');
+  });
+
+  // AC-F2.1
+  test('f2-typing-colon-adds-row', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 ColonAdds'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/anything/:id');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variables-section"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible();
+
+    const keyField = page.locator('[data-testid="path-variable-key-id"]');
+    await expect(keyField).toHaveValue('id');
+  });
+
+  // AC-F2.2
+  test('f2-typing-just-colon-no-row', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 JustColon'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:');
+
+    await openParamsTab(page);
+    // Section should not be present (length 0)
+    const section = page.locator('[data-testid="path-variables-section"]');
+    await expect(section).toHaveCount(0);
+  });
+
+  // AC-F2.3
+  test('f2-multiple-path-vars-ordered', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Multi'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:userId/posts/:postId');
+
+    await openParamsTab(page);
+    const section = page.locator('[data-testid="path-variables-section"]');
+    await expect(section).toBeVisible({ timeout: 5000 });
+
+    const rows = section.locator('tbody tr');
+    await expect(rows).toHaveCount(2);
+
+    // First row should be userId, second postId
+    const firstKey = rows.nth(0).locator('[data-testid^="path-variable-key-"]');
+    const secondKey = rows.nth(1).locator('[data-testid^="path-variable-key-"]');
+    await expect(firstKey).toHaveValue('userId');
+    await expect(secondKey).toHaveValue('postId');
+
+    await page.screenshot({ path: 'e2e/screenshots/path-vars-list-populated.png' });
+  });
+
+  // AC-F2.4
+  test('f2-reserved-char-strips-colon', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Strip'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.click();
+    await urlInput.fill('');
+    // Type the prefix as a fill (fast), then individual keystrokes for the colon-then-slash
+    await urlInput.fill('https://example.com/users/');
+    await urlInput.focus();
+    // Move caret to end
+    await page.keyboard.press('End');
+    await urlInput.pressSequentially(':/', { delay: 30 });
+
+    // The colon should have been stripped — final URL is /users//
+    await expect(urlInput).toHaveValue('https://example.com/users//');
+
+    await openParamsTab(page);
+    const section = page.locator('[data-testid="path-variables-section"]');
+    await expect(section).toHaveCount(0);
+  });
+
+  // AC-F2.5
+  test('f2-trailing-colon-preserved', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Trailing'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.click();
+    await urlInput.fill('https://example.com/users/');
+    await urlInput.focus();
+    await page.keyboard.press('End');
+    await urlInput.pressSequentially(':', { delay: 30 });
+
+    // Trailing : preserved
+    await expect(urlInput).toHaveValue('https://example.com/users/:');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variables-section"]')).toHaveCount(0);
+
+    // Continue typing 'id'
+    await urlInput.focus();
+    await page.keyboard.press('End');
+    await urlInput.pressSequentially('id', { delay: 30 });
+
+    await expect(urlInput).toHaveValue('https://example.com/users/:id');
+    await expect(page.locator('[data-testid="path-variables-section"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible();
+  });
+
+  // AC-F2.6
+  test('f2-removing-name-removes-row', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Remove'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible({ timeout: 5000 });
+
+    await urlInput.focus();
+    await page.keyboard.press('End');
+    // Backspace 3 times to remove ':id'
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+    await page.keyboard.press('Backspace');
+
+    await expect(urlInput).toHaveValue('https://example.com/users/');
+    await expect(page.locator('[data-testid="path-variables-section"]')).toHaveCount(0);
+  });
+
+  // AC-F2.8
+  test('f2-key-readonly', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 ReadOnly'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id');
+
+    await openParamsTab(page);
+    const keyField = page.locator('[data-testid="path-variable-key-id"]');
+    await expect(keyField).toBeVisible({ timeout: 5000 });
+    await expect(keyField).toHaveAttribute('readonly', '');
+    await expect(keyField).toHaveValue('id');
+
+    // Try to type — value must not change
+    await keyField.click({ force: true });
+    await page.keyboard.type('xyz', { delay: 20 });
+    await expect(keyField).toHaveValue('id');
+  });
+
+  // AC-F2.9, AC-F2.10
+  test('f2-value-edit-in-list', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 ValueEdit'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/anything/:id');
+
+    await openParamsTab(page);
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await expect(valueField).toBeVisible({ timeout: 5000 });
+    await valueField.fill('42');
+    await expect(valueField).toHaveValue('42');
+
+    await saveRequest(page);
+
+    // Re-check value persists in the editor (without reload, as a sanity check on save not stripping)
+    await expect(valueField).toHaveValue('42');
+  });
+
+  // AC-F1.2, AC-F2.10, AC-F2.11
+  test('f2-persistence-across-reload', async ({ page }) => {
+    const colName = uniqueName('PV F2 Persist');
+    await createTestRequest(page, colName);
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/anything/:id');
+
+    await openParamsTab(page);
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await valueField.fill('7');
+
+    await saveRequest(page);
+
+    // Reload page
+    await page.reload();
+    await expect(page.locator('.workspace-selector-trigger:not([disabled])')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.sidebar')).toBeVisible();
+
+    // Re-open the request
+    const collectionHeader = page.locator('.collection-header').filter({ hasText: colName });
+    await expect(collectionHeader).toBeVisible({ timeout: 10000 });
+    // Expand collection if collapsed
+    await collectionHeader.click().catch(() => {});
+    const requestItem = page.locator('.request-item').first();
+    await expect(requestItem).toBeVisible({ timeout: 10000 });
+    await requestItem.click();
+
+    await expect(page.locator('.request-editor')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.url-input')).toHaveValue('https://httpbin.org/anything/:id');
+
+    await openParamsTab(page);
+    const reloadedValue = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await expect(reloadedValue).toHaveValue('7');
+
+    // Send and verify substitution still works
+    await clearConsole(page);
+    await sendRequestAndWait(page);
+    const resolved = await getResolvedUrlFromConsole(page);
+    expect(resolved).not.toBeNull();
+    expect(resolved!).toContain('/anything/7');
+  });
+
+  // AC-F2.13
+  test('f2-curl-preview-matches', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Curl'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/anything/:id');
+
+    await openParamsTab(page);
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await valueField.fill('7');
+
+    await openCurlPanel(page);
+    const curl = await readCurlText(page);
+    expect(curl).toContain('/anything/7');
+    expect(curl).not.toContain(':id');
+
+    await page.screenshot({ path: 'e2e/screenshots/path-vars-curl-preview.png' });
+
+    // Edit value live and confirm curl updates
+    await valueField.fill('100');
+    // Allow re-render
+    await page.waitForTimeout(200);
+    const curl2 = await readCurlText(page);
+    expect(curl2).toContain('/anything/100');
+    expect(curl2).not.toContain('/anything/7');
+  });
+
+  // AC-F2.14
+  test('f2-duplicate-name-single-row', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Dup'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://httpbin.org/anything/:id/sub/:id');
+
+    await openParamsTab(page);
+    const section = page.locator('[data-testid="path-variables-section"]');
+    await expect(section).toBeVisible({ timeout: 5000 });
+    const rows = section.locator('tbody tr');
+    await expect(rows).toHaveCount(1);
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible();
+
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await valueField.fill('X');
+
+    await clearConsole(page);
+    await sendRequestAndWait(page);
+    const resolved = await getResolvedUrlFromConsole(page);
+    expect(resolved).not.toBeNull();
+    expect(resolved!).toContain('/anything/X/sub/X');
+  });
+
+  // AC-F2.15
+  test('f2-section-hidden-when-no-path-vars', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Hidden'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/api/users');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variables-section"]')).toHaveCount(0);
+  });
+
+  // AC-F1.9 — port number after host must NOT be parsed as a path variable
+  test('f1-port-not-treated-as-pathvar', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F1 Port'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://localhost:3000/api/:id');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variables-section"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible();
+    // The 3000 (port) MUST NOT have been parsed as a path-var row.
+    await expect(page.locator('[data-testid="path-variable-row-3000"]')).toHaveCount(0);
+    const rows = page.locator('[data-testid="path-variables-section"] tbody tr');
+    await expect(rows).toHaveCount(1);
+  });
+
+  // AC-F1.10 — `:` characters inside the query string must NOT be parsed as path variables
+  test('f1-query-colon-not-pathvar', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F1 Query'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/api/:id?ts=2024:01:01');
+
+    await openParamsTab(page);
+    await expect(page.locator('[data-testid="path-variables-section"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible();
+    // The :01 occurrences in the query string MUST NOT spawn rows.
+    await expect(page.locator('[data-testid="path-variable-row-01"]')).toHaveCount(0);
+    const rows = page.locator('[data-testid="path-variables-section"] tbody tr');
+    await expect(rows).toHaveCount(1);
+  });
+
+  // AC-F2.16 — query params and path vars coexist independently
+  test('f2-params-and-pathvars-coexist', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F2 Coexist'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id?active=true');
+
+    await openParamsTab(page);
+    // Path Variables row for :id
+    await expect(page.locator('[data-testid="path-variables-section"]')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-testid="path-variable-row-id"]')).toBeVisible();
+    // Query params table contains the active=true row
+    const paramsBody = page.locator('.params-editor table tbody');
+    await expect(paramsBody.locator('input[value="active"]')).toBeVisible();
+    await expect(paramsBody.locator('input[value="true"]')).toBeVisible();
+  });
+
+  // AC-F3.1, AC-F3.2
+  test('f3-overlay-highlight-on-url', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F3 Overlay'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id');
+
+    // The overlay element renders alongside the input when variables are present
+    const overlay = page.locator('.env-variable-input-wrapper:has(.url-input) .env-var-overlay');
+    await expect(overlay).toBeVisible({ timeout: 5000 });
+
+    // Highlight span for :id (resolved or unresolved depending on whether value is filled)
+    const highlight = overlay.locator('.env-var-highlight.path-resolved, .env-var-highlight.path-unresolved').filter({ hasText: ':id' });
+    await expect(highlight).toBeVisible();
+
+    await page.screenshot({ path: 'e2e/screenshots/path-vars-overlay-highlight.png' });
+  });
+
+  // AC-F3.1
+  test('f3-overlay-no-highlight-in-headers', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F3 NoHdr'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id');
+
+    await openHeadersTab(page);
+    const headersEditor = page.locator('.headers-editor');
+    await expect(headersEditor).toBeVisible();
+
+    const headerKey = headersEditor.locator('tbody tr').first().locator('input[placeholder="Header name"]');
+    const headerVal = headersEditor.locator('tbody tr').first().locator('input[placeholder="Value"]');
+    await headerKey.fill('X-Test');
+    await headerVal.fill(':id');
+
+    // The header value's wrapper should NOT contain a path-resolved/unresolved highlight
+    const headerWrapper = headersEditor.locator('tbody tr').first().locator('.env-variable-input-wrapper').last();
+    const pathHighlight = headerWrapper.locator('.env-var-highlight.path-resolved, .env-var-highlight.path-unresolved');
+    await expect(pathHighlight).toHaveCount(0);
+  });
+
+  // AC-F3.3
+  test('f3-popover-opens-on-hover', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F3 Popover'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id');
+
+    await openParamsTab(page);
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await valueField.fill('42');
+
+    // Hover over :id in the URL — compute pixel offset based on the input's font size
+    // The hover handler in EnvVariableInput uses charWidth = fontSize * 0.6 + paddingLeft.
+    // We'll dispatch a mousemove event at a position inside the :id token.
+    const url = 'https://example.com/users/:id';
+    const colonIdx = url.indexOf(':id');
+    const handle = await page.locator('.url-input').elementHandle();
+    if (!handle) throw new Error('url-input not found');
+
+    await page.evaluate(({ el, charIdx }) => {
+      const input = el as HTMLInputElement;
+      const rect = input.getBoundingClientRect();
+      const style = window.getComputedStyle(input);
+      const paddingLeft = parseFloat(style.paddingLeft);
+      const fontSize = parseFloat(style.fontSize);
+      const charWidth = fontSize * 0.6;
+      const x = rect.left + paddingLeft + charWidth * (charIdx + 1); // middle of token
+      const y = rect.top + rect.height / 2;
+      const evt = new MouseEvent('mousemove', { bubbles: true, clientX: x, clientY: y });
+      input.dispatchEvent(evt);
+    }, { el: handle, charIdx: colonIdx });
+
+    const popover = page.locator('.env-var-popover');
+    await expect(popover).toBeVisible({ timeout: 5000 });
+    await expect(popover).toContainText('id');
+    await expect(popover).toContainText('42');
+
+    await page.screenshot({ path: 'e2e/screenshots/path-vars-popover.png' });
+  });
+
+  // AC-F3.4
+  test('f3-popover-edits-value', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F3 PopEdit'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/users/:id');
+
+    await openParamsTab(page);
+    const valueField = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await valueField.fill('42');
+
+    const url = 'https://example.com/users/:id';
+    const colonIdx = url.indexOf(':id');
+    const handle = await page.locator('.url-input').elementHandle();
+    if (!handle) throw new Error('url-input not found');
+
+    await page.evaluate(({ el, charIdx }) => {
+      const input = el as HTMLInputElement;
+      const rect = input.getBoundingClientRect();
+      const style = window.getComputedStyle(input);
+      const paddingLeft = parseFloat(style.paddingLeft);
+      const fontSize = parseFloat(style.fontSize);
+      const charWidth = fontSize * 0.6;
+      const x = rect.left + paddingLeft + charWidth * (charIdx + 1);
+      const y = rect.top + rect.height / 2;
+      const evt = new MouseEvent('mousemove', { bubbles: true, clientX: x, clientY: y });
+      input.dispatchEvent(evt);
+    }, { el: handle, charIdx: colonIdx });
+
+    const popover = page.locator('.env-var-popover');
+    await expect(popover).toBeVisible({ timeout: 5000 });
+
+    // Click to enter edit mode
+    await popover.click();
+    const editInput = popover.locator('input[type="text"], textarea').first();
+    await expect(editInput).toBeVisible({ timeout: 5000 });
+    await editInput.fill('99');
+    await editInput.press('Enter');
+
+    // Path Variables row value should now be 99
+    const reloadedValue = page.locator('[data-testid="path-variable-value-input-id"]').locator('input').first();
+    await expect(reloadedValue).toHaveValue('99', { timeout: 5000 });
+  });
+
+  // AC-F1.5, AC-F3.5
+  test('f3-prefix-not-confused', async ({ page }) => {
+    await createTestRequest(page, uniqueName('PV F3 Prefix'));
+
+    const urlInput = page.locator('.url-input');
+    await urlInput.fill('https://example.com/api/:foo/:foobar');
+
+    await openParamsTab(page);
+    const fooValue = page.locator('[data-testid="path-variable-value-input-foo"]').locator('input').first();
+    const fooBarValue = page.locator('[data-testid="path-variable-value-input-foobar"]').locator('input').first();
+    await fooValue.fill('A');
+    await fooBarValue.fill('B');
+
+    // Both rows present
+    await expect(page.locator('[data-testid="path-variable-row-foo"]')).toBeVisible();
+    await expect(page.locator('[data-testid="path-variable-row-foobar"]')).toBeVisible();
+
+    // Hover :foo — popover shows foo (not foobar)
+    const url = 'https://example.com/api/:foo/:foobar';
+    const fooIdx = url.indexOf(':foo');
+    const fooBarIdx = url.indexOf(':foobar');
+
+    const handle = await page.locator('.url-input').elementHandle();
+    if (!handle) throw new Error('url-input not found');
+
+    const dispatchHover = async (charIdx: number) => {
+      await page.evaluate(({ el, idx }) => {
+        const input = el as HTMLInputElement;
+        const rect = input.getBoundingClientRect();
+        const style = window.getComputedStyle(input);
+        const paddingLeft = parseFloat(style.paddingLeft);
+        const fontSize = parseFloat(style.fontSize);
+        const charWidth = fontSize * 0.6;
+        const x = rect.left + paddingLeft + charWidth * (idx + 1);
+        const y = rect.top + rect.height / 2;
+        const evt = new MouseEvent('mousemove', { bubbles: true, clientX: x, clientY: y });
+        input.dispatchEvent(evt);
+      }, { el: handle, idx: charIdx });
+    };
+
+    await dispatchHover(fooIdx);
+    const popover = page.locator('.env-var-popover');
+    await expect(popover).toBeVisible({ timeout: 5000 });
+    await expect(popover).toContainText('foo');
+    // header text 'foo' must equal 'foo' (not 'foobar')
+    const headerText1 = (await popover.locator('.env-var-name').textContent()) || '';
+    expect(headerText1.trim().endsWith('foo')).toBeTruthy();
+
+    // Move away to clear, then hover :foobar
+    await page.mouse.move(0, 0);
+    await page.waitForTimeout(300);
+
+    await dispatchHover(fooBarIdx);
+    await expect(popover).toBeVisible({ timeout: 5000 });
+    const headerText2 = (await popover.locator('.env-var-name').textContent()) || '';
+    expect(headerText2.trim().endsWith('foobar')).toBeTruthy();
+  });
+});

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,6 +5,7 @@ v0.1.8 released — Workflow Builder, Collection Variables, Auth Inheritance
 
 ## Log
 <!-- Newest entries first. Format: - YYYY-MM-DDTHH:MMZ [status] feature-name — notes -->
+- 2026-04-27T00:00Z [DONE] path-variables — Postman-style path variable support (`/users/:id`). New `path_variables` JSONB column on `requests`; new shared `src/utils/substituteVariables.js` consolidating env/path-var substitution previously duplicated across `useResponseExecution`, `useWorkflowExecution`, `CurlPanel` (also fixes pre-existing workflow override bug where env couldn't override same-named collection var). Path Variables section inside Params tab below query params. URL parser skips `:` inside `scheme://host:port` and stops at `?`/`#`. EnvVariableInput overlay highlights `:name` green (via `--accent-success`) when caller passes `pathVariables` prop; VariablePopover extended with `kind:'path'` for hover-edit. Closes #38.
 - 2026-04-16T00:00Z [DONE] response-download — Download button on response toolbar for all body types (binary/JSON/text). New `src/utils/downloadResponse.js` helper; new Tauri `write_binary_file` command. Closes #29
 - 2026-04-16T00:00Z [DONE] v0.1.8 release — Changelog, README, website features updated
 - 2026-03-25T00:00Z [DONE] variable-popover-shared — Extracted VariablePopover to top-level context provider, shared across EnvVariableInput and JsonEditor

--- a/memory-bank/testBaseline.md
+++ b/memory-bank/testBaseline.md
@@ -12,8 +12,8 @@
 - Base URL: http://127.0.0.1:5173
 
 ## Progress
-- Completed: 39 / 40 flows
-- Current batch: Complete
+- Completed: 39 / 40 baseline flows + 22 path-variables tests
+- Current batch: Path Variables (#38) complete
 
 ---
 
@@ -195,6 +195,19 @@
 - [x] workspace-settings — e2e/admin.spec.ts — 1 test
 - [x] workspace-members — e2e/admin.spec.ts — 1 test
 - [x] theme-toggle — e2e/admin.spec.ts — 1 test
+
+### Batch 10: Path Variables (P0, issue #38) — 22 tests ✓
+- [x] f1-pure-substitute-url — e2e/path-variables.spec.ts
+- [x] f1-path-var-with-env-interp — e2e/path-variables.spec.ts
+- [x] f1-port-not-treated-as-pathvar — e2e/path-variables.spec.ts (`scheme://host:port` parser guard)
+- [x] f1-query-colon-not-pathvar — e2e/path-variables.spec.ts (`?` / `#` parser guard)
+- [x] f2-typing-colon-adds-row, f2-typing-just-colon-no-row, f2-multiple-path-vars-ordered — URL parsing
+- [x] f2-reserved-char-strips-colon, f2-trailing-colon-preserved, f2-removing-name-removes-row — URL editing
+- [x] f2-key-readonly, f2-value-edit-in-list, f2-persistence-across-reload — list interactions
+- [x] f2-curl-preview-matches, f2-duplicate-name-single-row, f2-section-hidden-when-no-path-vars — UX
+- [x] f2-params-and-pathvars-coexist — query params + path vars side-by-side
+- [x] f3-overlay-highlight-on-url, f3-overlay-no-highlight-in-headers — visual scoping
+- [x] f3-popover-opens-on-hover, f3-popover-edits-value, f3-prefix-not-confused — popover behavior
 
 ---
 

--- a/src/App.css
+++ b/src/App.css
@@ -1635,6 +1635,17 @@ body {
   background: rgba(var(--accent-warning-rgb), 0.15);
 }
 
+.env-var-highlight.path-resolved {
+  color: var(--accent-success);
+  background: rgba(var(--accent-success-rgb), 0.15);
+}
+
+.env-var-highlight.path-unresolved {
+  color: var(--accent-warning);
+  background: rgba(var(--accent-warning-rgb), 0.15);
+  text-decoration: underline dotted;
+}
+
 /* ============================================
    Request Actions Menu - Three Dot Menu
    ============================================ */

--- a/src/components/CurlPanel.jsx
+++ b/src/components/CurlPanel.jsx
@@ -7,6 +7,7 @@ import { EditorView } from '@codemirror/view';
 import { generateCurl } from './RequestEditor';
 import { useWorkbench } from '../contexts/WorkbenchContext';
 import { useToast } from './Toast';
+import { substituteEnv, substituteUrl } from '../utils/substituteVariables';
 
 const curlEditorTheme = EditorView.theme({
   '&': {
@@ -106,36 +107,15 @@ export function CurlPanel({ width, theme, onResize, onClose }) {
       }
     }
 
-    const sub = (text) => {
-      if (!text) return text;
-      // Build merged map: collection (lower priority) then env (higher priority overrides).
-      // Single substitution pass so env truly overrides — otherwise replacing collection first
-      // erases the {{key}} pattern before env ever sees it.
-      const resolved = new Map();
-      if (collectionVariables && collectionVariables.length > 0) {
-        for (const v of collectionVariables) {
-          if (v.enabled === false || !v.key) continue;
-          resolved.set(v.key, v.value || v.current_value || v.initial_value || '');
-        }
-      }
-      if (activeEnvironment?.variables) {
-        for (const v of activeEnvironment.variables) {
-          if (v.enabled === false || !v.key) continue;
-          resolved.set(v.key, v.value || v.current_value || v.initial_value || '');
-        }
-      }
-      let result = text;
-      for (const [key, value] of resolved) {
-        result = result.replace(new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g'), value);
-      }
-      return result;
-    };
+    const envOpts = { environment: activeEnvironment, collectionVariables };
+    const sub = (text) => substituteEnv(text, envOpts);
+    const subUrl = (url) => substituteUrl(url, { ...envOpts, pathVariables: req.path_variables || [] });
 
     const headers = (req.headers || []).map(h => ({ ...h, key: sub(h.key), value: sub(h.value) }));
     const fd = (req.form_data || []).map(f => ({ ...f, key: sub(f.key), value: f.type === 'file' ? f.value : sub(f.value) }));
     return generateCurl(
       req.method || 'GET',
-      sub(req.url || ''),
+      subUrl(req.url || ''),
       headers,
       sub(req.body || ''),
       req.body_type || 'none',

--- a/src/components/EnvVariableInput.jsx
+++ b/src/components/EnvVariableInput.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import * as data from '../data/index.js';
 import { useVariablePopover } from './VariablePopover';
+import { extractPathVarTokens } from '../utils/substituteVariables';
 
 // Component that wraps an input and adds hover-to-edit for environment variables
 export function EnvVariableInput({
@@ -14,7 +15,10 @@ export function EnvVariableInput({
   collectionVariables,
   rootCollectionId,
   onEnvironmentUpdate,
+  pathVariables,
+  onPathVariableValueChange,
   disabled = false,
+  ...rest
 }) {
   const variablePopover = useVariablePopover();
   // Autocomplete state
@@ -25,20 +29,35 @@ export function EnvVariableInput({
   const inputRef = useRef(null);
   const suggestionsRef = useRef(null);
 
-  // Find the variable at a given position in the text
+  // Find the variable at a given position in the text (env or path)
   const findVariableAtPosition = (text, pos) => {
-    const regex = /\{\{([^}]+)\}\}/g;
+    const envRegex = /\{\{([^}]+)\}\}/g;
     let match;
-    while ((match = regex.exec(text)) !== null) {
+    while ((match = envRegex.exec(text)) !== null) {
       const start = match.index;
       const end = match.index + match[0].length;
       if (pos >= start && pos <= end) {
         return {
+          kind: 'env',
           name: match[1].trim(),
           start,
           end,
           fullMatch: match[0],
         };
+      }
+    }
+    if (pathVariables && pathVariables.length > 0) {
+      const tokens = extractPathVarTokens(text);
+      for (const t of tokens) {
+        if (pos >= t.start && pos <= t.end) {
+          return {
+            kind: 'path',
+            name: t.key,
+            start: t.start,
+            end: t.end,
+            fullMatch: text.slice(t.start, t.end),
+          };
+        }
       }
     }
     return null;
@@ -66,8 +85,9 @@ export function EnvVariableInput({
     return null;
   };
 
-  // Check if the value contains any variables
-  const hasVariables = /\{\{[^}]+\}\}/.test(value);
+  // Check if the value contains any variables (env or path)
+  const hasVariables = /\{\{[^}]+\}\}/.test(value || '')
+    || (pathVariables?.length > 0 && extractPathVarTokens(value || '').length > 0);
 
   // Get filtered variables for autocomplete (merged collection + env vars)
   const getFilteredVariables = useCallback((filterText) => {
@@ -251,36 +271,56 @@ export function EnvVariableInput({
     };
   }, [showSuggestions]);
 
-  // Render highlighted text with variables styled
+  // Render highlighted text with variables styled (env + path)
   const renderHighlightedText = () => {
     if (!value) return null;
 
-    const parts = [];
-    const regex = /(\{\{[^}]+\}\})/g;
-    const segments = value.split(regex);
+    const tokens = [];
+    const envRegex = /\{\{[^}]+\}\}/g;
+    let m;
+    while ((m = envRegex.exec(value)) !== null) {
+      tokens.push({ start: m.index, end: m.index + m[0].length, kind: 'env', text: m[0] });
+    }
+    if (pathVariables && pathVariables.length > 0) {
+      for (const t of extractPathVarTokens(value)) {
+        tokens.push({
+          start: t.start,
+          end: t.end,
+          kind: 'path',
+          text: value.slice(t.start, t.end),
+          name: t.key,
+        });
+      }
+    }
+    tokens.sort((a, b) => a.start - b.start);
 
-    segments.forEach((segment, index) => {
-      if (segment.match(/^\{\{[^}]+\}\}$/)) {
-        // This is a variable
-        const varName = segment.slice(2, -2).trim();
+    const segments = [];
+    let cursor = 0;
+    for (const tok of tokens) {
+      if (tok.start < cursor) continue;
+      if (tok.start > cursor) segments.push({ text: value.slice(cursor, tok.start), isVar: false });
+      segments.push({ text: tok.text, isVar: true, kind: tok.kind, name: tok.name });
+      cursor = tok.end;
+    }
+    if (cursor < value.length) segments.push({ text: value.slice(cursor), isVar: false });
+
+    return segments.map((seg, i) => {
+      if (!seg.isVar) return <span key={i}>{seg.text}</span>;
+      if (seg.kind === 'env') {
+        const varName = seg.text.slice(2, -2).trim();
         const source = getVariableSource(varName);
         let varClass;
         if (!source && !activeEnvironment) varClass = 'no-env';
         else if (!source) varClass = 'unresolved';
         else if (source === 'collection') varClass = 'collection';
         else varClass = 'resolved';
-        parts.push(
-          <span key={index} className={`env-var-highlight ${varClass}`}>
-            {segment}
-          </span>
-        );
-      } else if (segment) {
-        // Regular text
-        parts.push(<span key={index}>{segment}</span>);
+        return <span key={i} className={`env-var-highlight ${varClass}`}>{seg.text}</span>;
       }
+      // kind === 'path'
+      const pv = pathVariables.find(p => p.key === seg.name);
+      const varClass = pv?.value ? 'path-resolved' : 'path-unresolved';
+      return <span key={i} className={`env-var-highlight ${varClass}`}>{seg.text}</span>;
     });
-
-    return parts;
   };
 
   // Handle mouse move to detect hover over variables → show shared popover
@@ -302,10 +342,23 @@ export function EnvVariableInput({
     if (variable) {
       const varStartX = rect.left + paddingLeft + (variable.start * charWidth);
       const varEndX = rect.left + paddingLeft + (variable.end * charWidth);
-      variablePopover.show({
-        varName: variable.name,
-        rect: { left: varStartX, right: varEndX, top: rect.top, bottom: rect.bottom },
-      });
+      const popoverRect = { left: varStartX, right: varEndX, top: rect.top, bottom: rect.bottom };
+      if (variable.kind === 'path') {
+        variablePopover.show({
+          varName: variable.name,
+          rect: popoverRect,
+          kind: 'path',
+          pathVariables,
+          onPathVarChange: (key, newValue) => {
+            onPathVariableValueChange?.(key, newValue);
+          },
+        });
+      } else {
+        variablePopover.show({
+          varName: variable.name,
+          rect: popoverRect,
+        });
+      }
     } else {
       variablePopover.hide();
     }
@@ -315,8 +368,10 @@ export function EnvVariableInput({
     variablePopover?.hide();
   };
 
+  const { 'data-testid': dataTestId, ...inputRest } = rest;
+
   return (
-    <div className="env-variable-input-wrapper">
+    <div className="env-variable-input-wrapper" data-testid={dataTestId}>
       {hasVariables && (
         <div className="env-var-overlay" aria-hidden="true">
           {renderHighlightedText()}
@@ -328,6 +383,7 @@ export function EnvVariableInput({
         className={`${className} ${hasVariables ? 'has-env-vars' : ''}`}
         placeholder={placeholder}
         value={value}
+        {...inputRest}
         onChange={handleInputChange}
         onKeyDown={handleInputKeyDown}
         onPaste={onPaste}

--- a/src/components/RequestBodyEditor.jsx
+++ b/src/components/RequestBodyEditor.jsx
@@ -86,6 +86,7 @@ export function RequestBodyEditor({
 
       {bodyType === 'form-data' && (
         <div className="form-data-editor">
+          <div className="kv-section">
           <table>
             <thead>
               <tr>
@@ -197,6 +198,7 @@ export function RequestBodyEditor({
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/src/components/RequestEditor.jsx
+++ b/src/components/RequestEditor.jsx
@@ -7,6 +7,7 @@ import { RequestBodyEditor } from './RequestBodyEditor';
 import { ScriptEditor } from './ScriptEditor';
 import { parseCurl } from './ImportCurlModal';
 import { useToast } from './Toast';
+import { reconcilePathVariables, sanitizeUrlForPathVars } from '../utils/substituteVariables';
 
 // Parse URL query string to params array
 function parseUrlParams(url) {
@@ -128,6 +129,7 @@ export function RequestEditor({
   const [authType, setAuthType] = useState('none');
   const [authToken, setAuthToken] = useState('');
   const [params, setParams] = useState([{ key: '', value: '', enabled: true }]);
+  const [pathVariables, setPathVariables] = useState([]);
   const [preScript, setPreScript] = useState('');
   const [postScript, setPostScript] = useState('');
   const [showSaveDropdown, setShowSaveDropdown] = useState(false);
@@ -135,19 +137,6 @@ export function RequestEditor({
   const [exampleName, setExampleName] = useState('');
   const lastUrlRef = useRef(url);
   const saveDropdownRef = useRef(null);
-
-  // Substitute environment variables in text
-  const substituteVariables = (text) => {
-    if (!text || !activeEnvironment) return text;
-    let result = text;
-    for (const v of activeEnvironment.variables) {
-      if (v.enabled && v.key) {
-        const regex = new RegExp(`\\{\\{${v.key}\\}\\}`, 'g');
-        result = result.replace(regex, v.value || '');
-      }
-    }
-    return result;
-  };
 
   // Initialize params from saved data or parse from URL
   const initializeParams = (savedParams, urlString) => {
@@ -185,6 +174,7 @@ export function RequestEditor({
       setAuthType(reqData.auth_type || 'none');
       setAuthToken(reqData.auth_token || '');
       setParams(initializeParams(reqData.params, reqData.url));
+      setPathVariables(reconcilePathVariables(reqData.url || '', reqData.path_variables || []));
       lastUrlRef.current = reqData.url || '';
     } else if (request) {
       setMethod(request.method || 'GET');
@@ -204,11 +194,12 @@ export function RequestEditor({
       setAuthType(request.auth_type || 'none');
       setAuthToken(request.auth_token || '');
       setParams(initializeParams(request.params, request.url));
+      setPathVariables(reconcilePathVariables(request.url || '', request.path_variables || []));
       setPreScript(request.pre_script || '');
       setPostScript(request.post_script || '');
       lastUrlRef.current = request.url || '';
     }
-  }, [isExample, example?.id, example?.request_data, request?.id, request?.method, request?.url, request?.headers, request?.body, request?.body_type, request?.form_data, request?.auth_type, request?.auth_token, request?.params, request?.pre_script, request?.post_script]);
+  }, [isExample, example?.id, example?.request_data, request?.id, request?.method, request?.url, request?.headers, request?.body, request?.body_type, request?.form_data, request?.auth_type, request?.auth_token, request?.params, request?.path_variables, request?.pre_script, request?.post_script]);
 
   // Helper to wrap changes for examples
   const notifyChange = (updates) => {
@@ -229,7 +220,9 @@ export function RequestEditor({
     notifyChange({ method: newMethod });
   };
 
-  const handleUrlChange = (newUrl) => {
+  const handleUrlChange = (rawUrl) => {
+    // Strip stray `:` followed by reserved chars (e.g. typing `/:/` collapses to `//`)
+    const newUrl = sanitizeUrlForPathVars(rawUrl);
     setUrl(newUrl);
 
     // Sync params from URL while preserving disabled params
@@ -248,8 +241,12 @@ export function RequestEditor({
     }
 
     setParams(mergedParams);
+
+    const newPathVars = reconcilePathVariables(newUrl, pathVariables);
+    setPathVariables(newPathVars);
+
     lastUrlRef.current = newUrl;
-    notifyChange({ url: newUrl, params: mergedParams });
+    notifyChange({ url: newUrl, params: mergedParams, path_variables: newPathVars });
   };
 
   const handleUrlPaste = async (e) => {
@@ -259,10 +256,12 @@ export function RequestEditor({
     try {
       const parsed = parseCurl(text);
       if (!parsed.url) return;
+      const pastedPathVars = reconcilePathVariables(parsed.url, []);
       setMethod(parsed.method);
       setUrl(parsed.url);
       setHeaders(parsed.headers);
       setParams(parseUrlParams(parsed.url).concat([{ key: '', value: '', enabled: true }]));
+      setPathVariables(pastedPathVars);
       lastUrlRef.current = parsed.url;
       if (parsed.bodyType === 'form-data' && parsed.formData?.length > 0) {
         setBodyType('form-data');
@@ -275,6 +274,7 @@ export function RequestEditor({
           body: '',
           body_type: 'form-data',
           form_data: parsed.formData,
+          path_variables: pastedPathVars,
         });
       } else {
         setBodyType(parsed.bodyType);
@@ -285,6 +285,7 @@ export function RequestEditor({
           headers: parsed.headers,
           body: parsed.body,
           body_type: parsed.bodyType,
+          path_variables: pastedPathVars,
         });
       }
       // Extract auth from parsed headers
@@ -366,6 +367,7 @@ export function RequestEditor({
         preScript,
         postScript,
         collectionId: request?.collection_id,
+        pathVariables,
       });
     }
   };
@@ -376,6 +378,7 @@ export function RequestEditor({
 
     // Filter out empty params but keep disabled ones
     const paramsToSave = params.filter((p) => p.key.trim()).map(p => ({ ...p, value: trimVars(p.value) }));
+    const pathVarsToSave = pathVariables.map(pv => ({ ...pv, value: trimVars(pv.value) }));
     const trimmedUrl = trimVars(url).trim();
     const trimmedBody = trimVars(body);
     const trimmedHeaders = headers.filter((h) => h.key).map(h => ({ ...h, value: trimVars(h.value) }));
@@ -395,6 +398,7 @@ export function RequestEditor({
           auth_type: authType,
           auth_token: trimmedAuthToken,
           params: paramsToSave,
+          path_variables: pathVarsToSave,
         },
         response_data: example?.response_data,
       });
@@ -409,6 +413,7 @@ export function RequestEditor({
         auth_type: authType,
         auth_token: trimmedAuthToken,
         params: paramsToSave,
+        path_variables: pathVarsToSave,
         pre_script: preScript,
         post_script: postScript,
       });
@@ -428,6 +433,7 @@ export function RequestEditor({
       auth_type: authType,
       auth_token: authToken,
       params: paramsToSave,
+      path_variables: pathVariables,
     };
     const responseData = response ? {
       status: response.status,
@@ -498,6 +504,14 @@ export function RequestEditor({
           collectionVariables={collectionVariables}
           rootCollectionId={rootCollectionId}
           onEnvironmentUpdate={onEnvironmentUpdate}
+          pathVariables={pathVariables}
+          onPathVariableValueChange={(key, newValue) => {
+            const updated = pathVariables.map(p =>
+              p.key === key ? { ...p, value: newValue } : p
+            );
+            setPathVariables(updated);
+            notifyChange({ path_variables: updated });
+          }}
           disabled={!canEdit}
         />
         {isExample ? (
@@ -513,6 +527,7 @@ export function RequestEditor({
               authType,
               authToken,
               exampleName: example?.name,
+              pathVariables,
             })}
             disabled={!url}
             title="Open in a new temporary tab to send request"
@@ -619,82 +634,137 @@ export function RequestEditor({
       <div className="request-content">
         {activeDetailTab === 'params' && (
           <div className="params-editor">
-            <table>
-              <thead>
-                <tr>
-                  <th style={{ width: '30px' }}></th>
-                  <th>Key</th>
-                  <th>Value</th>
-                  <th style={{ width: '40px' }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {params.map((param, index) => (
-                  <tr key={index}>
-                    <td>
-                      <Checkbox
-                        checked={param.enabled !== false}
-                        onChange={(e) => {
-                          const newParams = [...params];
-                          newParams[index] = { ...param, enabled: e.target.checked };
-                          handleParamsChange(newParams);
-                        }}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="text"
-                        placeholder="Key"
-                        value={param.key}
-                        onChange={(e) => {
-                          const newParams = [...params];
-                          newParams[index] = { ...param, key: e.target.value };
-                          // Add empty row if editing last row
-                          if (index === params.length - 1 && e.target.value) {
-                            newParams.push({ key: '', value: '', enabled: true });
-                          }
-                          handleParamsChange(newParams);
-                        }}
-                      />
-                    </td>
-                    <td>
-                      <EnvVariableInput
-                        value={param.value}
-                        onChange={(e) => {
-                          const newParams = [...params];
-                          newParams[index] = { ...param, value: e.target.value };
-                          handleParamsChange(newParams);
-                        }}
-                        placeholder="Value"
-                        activeEnvironment={activeEnvironment}
-                        collectionVariables={collectionVariables}
-                        rootCollectionId={rootCollectionId}
-                        onEnvironmentUpdate={onEnvironmentUpdate}
-                      />
-                    </td>
-                    <td>
-                      {param.key && (
-                        <button
-                          className="btn-icon small danger"
-                          onClick={() => {
-                            const newParams = params.filter((_, i) => i !== index);
-                            if (newParams.length === 0) {
+            <div className="kv-section">
+              <div className="kv-section-header">
+                <span className="kv-section-title">Query Params</span>
+              </div>
+              <table>
+                <thead>
+                  <tr>
+                    <th style={{ width: '30px' }}></th>
+                    <th>Key</th>
+                    <th>Value</th>
+                    <th style={{ width: '40px' }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {params.map((param, index) => (
+                    <tr key={index}>
+                      <td>
+                        <Checkbox
+                          checked={param.enabled !== false}
+                          onChange={(e) => {
+                            const newParams = [...params];
+                            newParams[index] = { ...param, enabled: e.target.checked };
+                            handleParamsChange(newParams);
+                          }}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="text"
+                          placeholder="Key"
+                          value={param.key}
+                          onChange={(e) => {
+                            const newParams = [...params];
+                            newParams[index] = { ...param, key: e.target.value };
+                            if (index === params.length - 1 && e.target.value) {
                               newParams.push({ key: '', value: '', enabled: true });
                             }
                             handleParamsChange(newParams);
                           }}
-                        >
-                          ×
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <p className="hint" style={{ marginTop: '12px' }}>
-              Query parameters sync with the URL automatically
-            </p>
+                        />
+                      </td>
+                      <td>
+                        <EnvVariableInput
+                          value={param.value}
+                          onChange={(e) => {
+                            const newParams = [...params];
+                            newParams[index] = { ...param, value: e.target.value };
+                            handleParamsChange(newParams);
+                          }}
+                          placeholder="Value"
+                          activeEnvironment={activeEnvironment}
+                          collectionVariables={collectionVariables}
+                          rootCollectionId={rootCollectionId}
+                          onEnvironmentUpdate={onEnvironmentUpdate}
+                        />
+                      </td>
+                      <td>
+                        {param.key && (
+                          <button
+                            className="btn-icon small danger"
+                            onClick={() => {
+                              const newParams = params.filter((_, i) => i !== index);
+                              if (newParams.length === 0) {
+                                newParams.push({ key: '', value: '', enabled: true });
+                              }
+                              handleParamsChange(newParams);
+                            }}
+                          >
+                            ×
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {pathVariables.length > 0 && (
+              <div className="kv-section" data-testid="path-variables-section">
+                <div className="kv-section-header">
+                  <span className="kv-section-title">Path Variables</span>
+                </div>
+                <table>
+                  <thead>
+                    <tr>
+                      <th style={{ width: '30px' }}></th>
+                      <th>Key</th>
+                      <th>Value</th>
+                      <th style={{ width: '40px' }}></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pathVariables.map((pv) => (
+                      <tr key={pv.key} data-testid={`path-variable-row-${pv.key}`}>
+                        <td></td>
+                        <td>
+                          <input
+                            type="text"
+                            className="path-var-key-readonly"
+                            value={pv.key}
+                            readOnly
+                            tabIndex={-1}
+                            data-testid={`path-variable-key-${pv.key}`}
+                            title="Edit the URL above to change this key"
+                          />
+                        </td>
+                        <td>
+                          <EnvVariableInput
+                            value={pv.value}
+                            onChange={(e) => {
+                              const updated = pathVariables.map(p =>
+                                p.key === pv.key ? { ...p, value: e.target.value } : p
+                              );
+                              setPathVariables(updated);
+                              notifyChange({ path_variables: updated });
+                            }}
+                            placeholder="Value"
+                            activeEnvironment={activeEnvironment}
+                            collectionVariables={collectionVariables}
+                            rootCollectionId={rootCollectionId}
+                            onEnvironmentUpdate={onEnvironmentUpdate}
+                            data-testid={`path-variable-value-input-${pv.key}`}
+                          />
+                        </td>
+                        <td></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
         )}
 
@@ -760,61 +830,63 @@ export function RequestEditor({
 
         {activeDetailTab === 'headers' && (
           <div className="headers-editor">
-            <table>
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>Key</th>
-                  <th>Value</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {headers.map((header, index) => (
-                  <tr key={index}>
-                    <td>
-                      <Checkbox
-                        checked={header.enabled !== false}
-                        onChange={(e) => updateHeader(index, 'enabled', e.target.checked)}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="text"
-                        placeholder="Header name"
-                        value={header.key}
-                        onChange={(e) => {
-                          const newHeaders = [...headers];
-                          newHeaders[index] = { ...header, key: e.target.value };
-                          if (index === headers.length - 1 && e.target.value) {
-                            newHeaders.push({ key: '', value: '', enabled: true });
-                          }
-                          handleHeadersChange(newHeaders);
-                        }}
-                      />
-                    </td>
-                    <td>
-                      <EnvVariableInput
-                        value={header.value}
-                        onChange={(e) => updateHeader(index, 'value', e.target.value)}
-                        placeholder="Value"
-                        activeEnvironment={activeEnvironment}
-                        collectionVariables={collectionVariables}
-                        rootCollectionId={rootCollectionId}
-                        onEnvironmentUpdate={onEnvironmentUpdate}
-                      />
-                    </td>
-                    <td>
-                      {header.key && (
-                        <button className="btn-icon small" onClick={() => removeHeader(index)}>
-                          ×
-                        </button>
-                      )}
-                    </td>
+            <div className="kv-section">
+              <table>
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th>Key</th>
+                    <th>Value</th>
+                    <th></th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {headers.map((header, index) => (
+                    <tr key={index}>
+                      <td>
+                        <Checkbox
+                          checked={header.enabled !== false}
+                          onChange={(e) => updateHeader(index, 'enabled', e.target.checked)}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          type="text"
+                          placeholder="Header name"
+                          value={header.key}
+                          onChange={(e) => {
+                            const newHeaders = [...headers];
+                            newHeaders[index] = { ...header, key: e.target.value };
+                            if (index === headers.length - 1 && e.target.value) {
+                              newHeaders.push({ key: '', value: '', enabled: true });
+                            }
+                            handleHeadersChange(newHeaders);
+                          }}
+                        />
+                      </td>
+                      <td>
+                        <EnvVariableInput
+                          value={header.value}
+                          onChange={(e) => updateHeader(index, 'value', e.target.value)}
+                          placeholder="Value"
+                          activeEnvironment={activeEnvironment}
+                          collectionVariables={collectionVariables}
+                          rootCollectionId={rootCollectionId}
+                          onEnvironmentUpdate={onEnvironmentUpdate}
+                        />
+                      </td>
+                      <td>
+                        {header.key && (
+                          <button className="btn-icon small" onClick={() => removeHeader(index)}>
+                            ×
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         )}
 

--- a/src/components/VariablePopover.jsx
+++ b/src/components/VariablePopover.jsx
@@ -47,16 +47,29 @@ export function VariablePopoverProvider({ children, activeEnvironment, collectio
     }, 150);
   }, [isEditing, clearHideTimeout]);
 
-  const show = useCallback(({ varName, rect }) => {
+  const show = useCallback(({ varName, rect, kind = 'env', pathVariables: pvList, onPathVarChange }) => {
     // Don't interrupt edit mode
     if (isEditing) { clearHideTimeout(); return; }
     // Don't show while selecting text
     const sel = window.getSelection();
     if (sel && sel.toString().length > 0) return;
     clearHideTimeout();
+    if (kind === 'path') {
+      const pv = pvList?.find(p => p.key === varName);
+      setState({
+        varName,
+        rect,
+        kind: 'path',
+        source: 'path',
+        value: pv?.value ?? '',
+        onPathVarChange,
+      });
+      setEditValue(pv?.value || '');
+      return;
+    }
     const source = getVariableSource(varName);
     const value = getVariableValue(varName);
-    setState({ varName, rect, source, value });
+    setState({ varName, rect, kind: 'env', source, value });
     setEditValue(value || '');
   }, [isEditing, getVariableSource, getVariableValue, clearHideTimeout]);
 
@@ -71,6 +84,13 @@ export function VariablePopoverProvider({ children, activeEnvironment, collectio
       // Minify JSON before saving
       let valueToSave = editValue;
       try { valueToSave = JSON.stringify(JSON.parse(editValue)); } catch {}
+
+      if (state.kind === 'path' && state.onPathVarChange) {
+        state.onPathVarChange(state.varName, valueToSave);
+        setIsEditing(false);
+        setState(null);
+        return;
+      }
 
       if (state.source === 'collection' && rootCollectionId) {
         await data.updateCollectionVariableCurrentValues(rootCollectionId, {
@@ -156,12 +176,17 @@ export function VariablePopoverProvider({ children, activeEnvironment, collectio
             <span className={`env-var-name ${state.source || ''}`}>
               {state.source === 'collection' && <span className="suggestion-source-badge collection">C</span>}
               {state.source === 'env' && <span className="suggestion-source-badge env">E</span>}
+              {state.kind === 'path' && <span className="suggestion-source-badge path">P</span>}
               {state.varName}
             </span>
-            {state.source !== 'collection' && (
-              activeEnvironment
-                ? <span className="env-var-env">{activeEnvironment.name}</span>
-                : <span className="env-var-env no-env">No Environment</span>
+            {state.kind === 'path' ? (
+              <span className="env-var-env path">Path</span>
+            ) : (
+              state.source !== 'collection' && (
+                activeEnvironment
+                  ? <span className="env-var-env">{activeEnvironment.name}</span>
+                  : <span className="env-var-env no-env">No Environment</span>
+              )
             )}
           </div>
           {(() => {

--- a/src/contexts/WorkbenchContext.jsx
+++ b/src/contexts/WorkbenchContext.jsx
@@ -219,6 +219,7 @@ export function WorkbenchProvider({ children, prompt, confirm, toast }) {
           body: tab.request.body, body_type: tab.request.body_type, form_data: tab.request.form_data,
           auth_type: tab.request.auth_type, auth_token: tab.request.auth_token,
           pre_script: tab.request.pre_script, post_script: tab.request.post_script,
+          path_variables: tab.request.path_variables,
         });
       } else if (tab.type === 'example' && tab.example) {
         originals[tab.id] = JSON.stringify({
@@ -438,6 +439,7 @@ export function WorkbenchProvider({ children, prompt, confirm, toast }) {
           body_type: currentSaveState.selectedRequest.body_type, auth_type: currentSaveState.selectedRequest.auth_type,
           auth_token: currentSaveState.selectedRequest.auth_token, params: currentSaveState.selectedRequest.params,
           pre_script: currentSaveState.selectedRequest.pre_script, post_script: currentSaveState.selectedRequest.post_script,
+          path_variables: currentSaveState.selectedRequest.path_variables,
         });
       }
     };

--- a/src/data/supabase/requests.js
+++ b/src/data/supabase/requests.js
@@ -8,6 +8,9 @@ const parseRequest = (request) => ({
   headers: typeof request.headers === 'string' ? JSON.parse(request.headers || '[]') : (request.headers || []),
   params: typeof request.params === 'string' ? JSON.parse(request.params || '[]') : (request.params || []),
   form_data: typeof request.form_data === 'string' ? JSON.parse(request.form_data || '[]') : (request.form_data || []),
+  path_variables: typeof request.path_variables === 'string'
+    ? JSON.parse(request.path_variables || '[]')
+    : (request.path_variables || []),
 });
 
 export const getRequests = async (collectionId) => {
@@ -44,6 +47,7 @@ export const createRequest = async (request) => {
       body_type: request.body_type || 'none',
       form_data: request.form_data ? JSON.stringify(request.form_data) : null,
       params: request.params ? JSON.stringify(request.params) : null,
+      path_variables: request.path_variables ? JSON.stringify(request.path_variables) : '[]',
       auth_type: request.auth_type || 'none',
       auth_token: request.auth_token || '',
       pre_script: request.pre_script || '',
@@ -72,6 +76,7 @@ export const updateRequest = async (id, updates) => {
   if (updates.body_type !== undefined) updateData.body_type = updates.body_type;
   if (updates.form_data !== undefined) updateData.form_data = JSON.stringify(updates.form_data);
   if (updates.params !== undefined) updateData.params = JSON.stringify(updates.params);
+  if (updates.path_variables !== undefined) updateData.path_variables = JSON.stringify(updates.path_variables);
   if (updates.auth_type !== undefined) updateData.auth_type = updates.auth_type;
   if (updates.auth_token !== undefined) updateData.auth_token = updates.auth_token;
   if (updates.pre_script !== undefined) updateData.pre_script = updates.pre_script;

--- a/src/hooks/useConflictResolution.js
+++ b/src/hooks/useConflictResolution.js
@@ -45,6 +45,7 @@ export function useConflictResolution({
         auth_token: updated.auth_token,
         pre_script: savedPreScript,
         post_script: savedPostScript,
+        path_variables: updated.path_variables,
       });
 
       setOpenTabs((prev) => prev.map((item) => (
@@ -175,6 +176,7 @@ export function useConflictResolution({
           auth_token: tab.request.auth_token,
           params: tab.request.params,
           form_data: tab.request.form_data,
+          path_variables: tab.request.path_variables,
         });
         openRequestInTab(newRequest);
       }

--- a/src/hooks/useRequestActions.js
+++ b/src/hooks/useRequestActions.js
@@ -168,6 +168,7 @@ export function useRequestActions({
       auth_token: fullRequest.auth_token,
       pre_script: fullRequest.pre_script,
       post_script: fullRequest.post_script,
+      path_variables: fullRequest.path_variables,
     });
 
     const hasBody = fullRequest.body_type && fullRequest.body_type !== 'none';

--- a/src/hooks/useResponseExecution.js
+++ b/src/hooks/useResponseExecution.js
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import JSON5 from 'json5';
 import * as data from '../data/index.js';
 import { applyEnvironmentUpdates, executeScript } from '../utils/scriptRunner';
+import { substituteEnv, substituteUrl } from '../utils/substituteVariables';
 import useWorkbenchStore from '../stores/workbenchStore';
 import useConsoleStore from '../stores/consoleStore';
 
@@ -82,6 +83,7 @@ export function useResponseExecution({
     preScript,
     postScript,
     collectionId,
+    pathVariables = [],
   }) => {
     const controller = new AbortController();
     abortRef.current = controller;
@@ -170,42 +172,27 @@ export function useResponseExecution({
         }
       }
 
-      const substituteWithEnv = (text) => {
-        if (!text) return text;
+      const subEnv = (text) => substituteEnv(text, {
+        environment: currentEnv,
+        collectionVariables: collectionVars,
+      });
 
-        // Build merged map: collection (lower priority) then env (higher priority overrides).
-        // Single substitution pass so env truly overrides — otherwise replacing collection first
-        // erases the {{key}} pattern before env ever sees it.
-        const resolved = new Map();
-        for (const variable of collectionVars) {
-          if (!variable.enabled || !variable.key) continue;
-          resolved.set(variable.key, variable.value || variable.current_value || variable.initial_value || '');
-        }
-        if (currentEnv) {
-          for (const variable of currentEnv.variables) {
-            if (!variable.enabled || !variable.key) continue;
-            resolved.set(variable.key, variable.value || variable.current_value || variable.initial_value || '');
-          }
-        }
-        let result = text;
-        for (const [key, value] of resolved) {
-          result = result.replace(new RegExp(`\\{\\{\\s*${key}\\s*\\}\\}`, 'g'), value);
-        }
-        return result;
-      };
-
-      const resolvedUrl = substituteWithEnv(url);
+      const resolvedUrl = substituteUrl(url, {
+        environment: currentEnv,
+        collectionVariables: collectionVars,
+        pathVariables,
+      });
       const resolvedHeaders = headers.map((header) => ({
         ...header,
-        key: substituteWithEnv(header.key),
-        value: substituteWithEnv(header.value),
+        key: subEnv(header.key),
+        value: subEnv(header.value),
       }));
-      const resolvedBody = substituteWithEnv(body);
-      const resolvedAuthToken = substituteWithEnv(authToken);
+      const resolvedBody = subEnv(body);
+      const resolvedAuthToken = subEnv(authToken);
       const resolvedFormData = formData?.map((field) => ({
         ...field,
-        key: substituteWithEnv(field.key),
-        value: field.type === 'file' ? field.value : substituteWithEnv(field.value),
+        key: subEnv(field.key),
+        value: field.type === 'file' ? field.value : subEnv(field.value),
       }));
 
       if (bodyType === 'json' && resolvedBody) {

--- a/src/hooks/useWorkflowExecution.js
+++ b/src/hooks/useWorkflowExecution.js
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import JSON5 from 'json5';
 import * as data from '../data/index.js';
 import { applyEnvironmentUpdates, executeScript } from '../utils/scriptRunner';
+import { substituteEnv, substituteUrl } from '../utils/substituteVariables';
 
 function stripJsonComments(text) {
   if (!text?.trim()) return text;
@@ -135,34 +136,24 @@ export function useWorkflowExecution({ activeEnvironment, collections, openTabs,
           }
         }
 
-        // Substitute environment variables
-        const substitute = (text) => {
-          if (!text) return text;
-          let result = text;
-          for (const v of collectionVars) {
-            if (v.enabled && v.key) {
-              result = result.replace(new RegExp(`\\{\\{\\s*${v.key}\\s*\\}\\}`, 'g'), v.value || v.current_value || v.initial_value || '');
-            }
-          }
-          if (currentEnv) {
-            for (const v of currentEnv.variables) {
-              if (v.enabled && v.key) {
-                result = result.replace(new RegExp(`\\{\\{\\s*${v.key}\\s*\\}\\}`, 'g'), v.value || v.current_value || v.initial_value || '');
-              }
-            }
-          }
-          return result;
-        };
+        const subEnv = (text) => substituteEnv(text, {
+          environment: currentEnv,
+          collectionVariables: collectionVars,
+        });
 
-        const resolvedUrl = substitute(request.url);
+        const resolvedUrl = substituteUrl(request.url, {
+          environment: currentEnv,
+          collectionVariables: collectionVars,
+          pathVariables: request.path_variables || [],
+        });
         const resolvedHeaders = (request.headers || [])
           .filter(h => h.enabled !== false)
-          .map(h => ({ ...h, key: substitute(h.key), value: substitute(h.value) }));
-        const resolvedBody = substitute(request.body);
-        const resolvedAuthToken = substitute(authToken);
+          .map(h => ({ ...h, key: subEnv(h.key), value: subEnv(h.value) }));
+        const resolvedBody = subEnv(request.body);
+        const resolvedAuthToken = subEnv(authToken);
         const resolvedFormData = (request.form_data || [])
           .filter(f => f.enabled !== false)
-          .map(f => ({ ...f, key: substitute(f.key), value: f.type === 'file' ? f.value : substitute(f.value) }));
+          .map(f => ({ ...f, key: subEnv(f.key), value: f.type === 'file' ? f.value : subEnv(f.value) }));
 
         const bodyType = request.body_type || 'none';
 

--- a/src/stores/workbenchStore.js
+++ b/src/stores/workbenchStore.js
@@ -81,6 +81,7 @@ const useWorkbenchStore = create((set, get) => ({
           body: request.body, body_type: request.body_type, form_data: request.form_data,
           auth_type: request.auth_type, auth_token: request.auth_token,
           pre_script: request.pre_script, post_script: request.post_script,
+          path_variables: request.path_variables,
         });
         const dirty = current !== _originalRequests[tab.id];
         return { ...tab, request, dirty };
@@ -94,6 +95,7 @@ const useWorkbenchStore = create((set, get) => ({
           body: request.body, body_type: request.body_type, form_data: request.form_data,
           auth_type: request.auth_type, auth_token: request.auth_token,
           pre_script: request.pre_script, post_script: request.post_script,
+          path_variables: request.path_variables,
         });
         const dirty = current !== _originalRequests[tab.id];
         return (dirty && previewTabId === tab.id) ? null : previewTabId;

--- a/src/styles/request-editor.css
+++ b/src/styles/request-editor.css
@@ -1184,6 +1184,32 @@
   color: var(--text-primary);
 }
 
+/* Compact TypeSelector inside .kv-section rows — match cell input height */
+.kv-section .type-selector-trigger,
+.kv-section .form-data-editor .type-selector-trigger {
+  height: 24px;
+  padding: 0 4px 0 6px;
+  gap: 4px;
+}
+
+.kv-section .type-selector-icon {
+  width: 14px;
+  height: 14px;
+  background: transparent;
+  border-radius: 0;
+}
+
+.kv-section .type-selector-value {
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.kv-section .btn-select-file {
+  padding: 4px var(--space-2);
+  font-size: 11px;
+  gap: 4px;
+}
+
 .file-input-wrapper {
   display: flex;
   align-items: center;
@@ -1268,5 +1294,52 @@
 .btn-example:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Compact key/value sections (Query Params + Path Variables share this) */
+.kv-section + .kv-section {
+  margin-top: var(--space-3);
+}
+
+.kv-section-header {
+  padding: var(--space-1) var(--space-3) var(--space-1);
+}
+
+.kv-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+}
+
+.kv-section table th {
+  padding: var(--space-1) var(--space-3);
+  font-size: 9px;
+}
+
+.kv-section td {
+  padding: 2px var(--space-1);
+}
+
+.kv-section input[type="text"] {
+  padding: 4px var(--space-2);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.path-var-key-readonly {
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: default;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  width: 100%;
+}
+
+.path-var-key-readonly:focus {
+  outline: none;
+  border-color: var(--border-primary);
+  background: var(--bg-input);
 }
 

--- a/src/styles/response-viewer.css
+++ b/src/styles/response-viewer.css
@@ -1291,13 +1291,17 @@
   background: var(--bg-elevated);
   border: 1px solid var(--border-secondary);
   border-radius: var(--radius-md);
-  /* Two-layer shadow: a subtle accent ring for presence + an ambient shadow
-     so the dock reads clearly against both light and dark JSON content. */
+  max-width: calc(100% - 24px);
+  transition: width 0.15s ease, box-shadow 0.15s ease;
+}
+
+/* Two-layer shadow appears only on hover or when the search input/buttons
+   are focused. Keeps the dock visually quiet at rest. */
+.response-json-dock:hover,
+.response-json-dock:focus-within {
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--accent-primary) 14%, transparent),
     var(--shadow-lg);
-  max-width: calc(100% - 24px);
-  transition: width 0.15s ease;
 }
 
 .response-json-dock-btn {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -74,8 +74,22 @@
   color: var(--accent-warning, #f59e0b);
 }
 
+.suggestion-source-badge.path {
+  background: rgba(var(--accent-success-rgb, 34, 197, 94), 0.15);
+  color: var(--accent-success, #22c55e);
+}
+
 .env-var-env.collection-var {
   color: var(--accent-warning, #f59e0b);
+}
+
+.env-var-name.path {
+  color: var(--accent-success);
+}
+
+.env-var-env.path {
+  background: rgba(var(--accent-success-rgb, 34, 197, 94), 0.15);
+  color: var(--accent-success);
 }
 
 .env-var-popover {

--- a/src/utils/substituteVariables.js
+++ b/src/utils/substituteVariables.js
@@ -1,0 +1,164 @@
+// Shared variable substitution util.
+// Single source of truth for {{env}}/{{collection}}/{:path} substitution
+// across request execution, workflow execution, and cURL preview.
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Single-pass merge — collection first, env overrides. Avoids the bug where
+// running collection sub then env sub sequentially makes env unable to override
+// because the first pass already replaced the {{key}} pattern.
+function buildEnvMap({ environment, collectionVariables }) {
+  const resolved = new Map();
+  if (collectionVariables) {
+    for (const v of collectionVariables) {
+      if (v.enabled === false || !v.key) continue;
+      resolved.set(v.key, v.value ?? v.current_value ?? v.initial_value ?? '');
+    }
+  }
+  if (environment?.variables) {
+    for (const v of environment.variables) {
+      if (v.enabled === false || !v.key) continue;
+      resolved.set(v.key, v.value ?? v.current_value ?? v.initial_value ?? '');
+    }
+  }
+  return resolved;
+}
+
+function applyEnvSubstitution(text, envMap) {
+  if (!text) return text;
+  let result = text;
+  for (const [key, value] of envMap) {
+    result = result.replace(
+      new RegExp(`\\{\\{\\s*${escapeRegex(key)}\\s*\\}\\}`, 'g'),
+      value ?? ''
+    );
+  }
+  return result;
+}
+
+// Reserved characters that terminate a path variable name.
+// RFC 3986 reserved chars + space + colon (a second colon ends the variable).
+export const PATH_VAR_RESERVED = new Set([
+  '/', '?', '#', '[', ']', '@',
+  '!', '$', '&', "'", '(', ')', '*', '+', ',', ';', '=',
+  ' ', ':',
+]);
+
+// Compute the [pathStart, pathEnd) substring of a URL where path-variable
+// tokens are valid. Skips scheme://host:port and stops at ? or #.
+function computePathRange(url) {
+  let pathStart = 0;
+  const schemeMatch = url.match(/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//);
+  if (schemeMatch) {
+    const afterScheme = schemeMatch[0].length;
+    const firstSlash = url.indexOf('/', afterScheme);
+    pathStart = firstSlash === -1 ? url.length : firstSlash;
+  }
+  let pathEnd = url.length;
+  const queryStart = url.indexOf('?', pathStart);
+  if (queryStart !== -1) pathEnd = Math.min(pathEnd, queryStart);
+  const hashStart = url.indexOf('#', pathStart);
+  if (hashStart !== -1) pathEnd = Math.min(pathEnd, hashStart);
+  return { pathStart, pathEnd };
+}
+
+// Substitute {{env}} and {{collection}} variables in arbitrary text.
+// Used for headers, body, auth, form-data, query params.
+export function substituteEnv(text, { environment, collectionVariables } = {}) {
+  if (!text) return text;
+  return applyEnvSubstitution(text, buildEnvMap({ environment, collectionVariables }));
+}
+
+// Substitute the URL: applies path-vars first (with their values env-resolved),
+// then env substitution on whatever remains.
+export function substituteUrl(
+  url,
+  { environment, collectionVariables, pathVariables } = {}
+) {
+  if (!url) return url;
+  const envMap = buildEnvMap({ environment, collectionVariables });
+
+  let result = url;
+  if (pathVariables && pathVariables.length > 0) {
+    // Build the lookahead character class from PATH_VAR_RESERVED so it stays
+    // in lockstep with the parser. \s covers space; the rest are literal escapes.
+    const reservedChars = Array.from(PATH_VAR_RESERVED)
+      .filter(ch => ch !== ' ')
+      .map(ch => escapeRegex(ch))
+      .join('');
+    const lookahead = `(?=$|[${reservedChars}\\s])`;
+    for (const pv of pathVariables) {
+      if (!pv.key) continue;
+      const resolvedValue = applyEnvSubstitution(pv.value || '', envMap);
+      const pattern = new RegExp(`:${escapeRegex(pv.key)}${lookahead}`, 'g');
+      result = result.replace(pattern, resolvedValue);
+    }
+  }
+  return applyEnvSubstitution(result, envMap);
+}
+
+// Parse :name tokens out of a URL string in order.
+// Returns Array<{ key, start, end }>.
+//
+// Skips `:` in scheme://host:port and ignores everything after ? or #.
+export function extractPathVarTokens(url) {
+  if (!url) return [];
+  const tokens = [];
+  const { pathStart, pathEnd } = computePathRange(url);
+  let i = pathStart;
+  while (i < pathEnd) {
+    const ch = url[i];
+    if (ch === ':' && url[i - 1] !== ':' && url[i + 1] !== ':') {
+      let j = i + 1;
+      while (j < pathEnd && !PATH_VAR_RESERVED.has(url[j])) j++;
+      if (j > i + 1) {
+        tokens.push({ key: url.slice(i + 1, j), start: i, end: j });
+        i = j;
+        continue;
+      }
+    }
+    i++;
+  }
+  return tokens;
+}
+
+// Strip stray `:` followed immediately by a reserved char (or a non-name char).
+// Trailing `:` at end-of-string is preserved (user may still be typing).
+// `:` inside the host portion (scheme://host:port) is preserved.
+export function sanitizeUrlForPathVars(url) {
+  if (!url) return url;
+  const { pathStart, pathEnd } = computePathRange(url);
+  let result = '';
+  for (let i = 0; i < url.length; i++) {
+    const ch = url[i];
+    // Only sanitize within the path portion
+    if (ch === ':' && i >= pathStart && i < pathEnd) {
+      const next = url[i + 1];
+      if (next !== undefined && PATH_VAR_RESERVED.has(next) && next !== ':') {
+        continue;
+      }
+    }
+    result += ch;
+  }
+  return result;
+}
+
+// Reconcile current path-variables list against the URL.
+// - For each token in URL: keep existing value if key matches.
+// - For each entry in list NOT in URL: drop it.
+// - New keys appended in URL order with empty value.
+// - Duplicate keys in URL collapse to a single row (first occurrence).
+export function reconcilePathVariables(url, currentPathVars) {
+  const tokens = extractPathVarTokens(url);
+  const seen = new Set();
+  const result = [];
+  for (const t of tokens) {
+    if (seen.has(t.key)) continue;
+    seen.add(t.key);
+    const existing = currentPathVars?.find(pv => pv.key === t.key);
+    result.push({ key: t.key, value: existing?.value || '' });
+  }
+  return result;
+}

--- a/supabase/migrations/20260424000000_request_path_variables.sql
+++ b/supabase/migrations/20260424000000_request_path_variables.sql
@@ -1,0 +1,11 @@
+-- ============================================
+-- Request Path Variables
+-- Add path_variables JSONB column to requests
+-- to support :name path-variable substitution
+-- ============================================
+
+ALTER TABLE requests
+  ADD COLUMN IF NOT EXISTS path_variables JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN requests.path_variables IS
+  'Path variables declared inline in url via :name syntax. Array of {key, value}, order matches URL order.';


### PR DESCRIPTION
Closes #38.

## Summary
- Postman-style `:name` path variables in the URL, scoped per-request. List rendered inside the Params tab below the query params table when present.
- `path_variables` is a new JSONB column on `requests`. Values may reference `{{env_var}}`, resolved before path substitution and before the rest of the URL is env-substituted.
- All three previously-duplicated substitution sites (`useResponseExecution`, `useWorkflowExecution`, `CurlPanel`) now share `src/utils/substituteVariables.js`. As a side benefit this fixes a pre-existing workflow bug where env vars couldn't override a same-named collection var.
- URL parser explicitly skips `:` inside `scheme://host:port` and stops at `?` / `#`, so `https://localhost:3000/api/:id` and `/api/:id?ts=2024:01:01` resolve to a single `:id` row each.
- Highlight + popover: `:name` shows green (`--accent-success`) in the URL input overlay, distinguishing path vars from env (blue) and collection (orange). Hover opens the existing `VariablePopover` extended with a `path` kind so the value can be edited inline.

## Other UI tweaks bundled in
- Both tables in the Params tab (Query Params + Path Variables) + Headers + Body form-data wrapped in compact `.kv-section` rows.
- `TypeSelector` trigger and Select File button shrunk to match the new cell input height.
- Response JSON dock no longer shows the heavy shadow at rest — appears only on `:hover` / `:focus-within`.

## Test plan
- [x] `npm run build` clean.
- [x] `e2e/path-variables.spec.ts` — 22 new tests, all green against real local Supabase + httpbin. Covers all spec ACs incl. parser guards (port, query-string colon), env-in-path-var-value interpolation, cURL preview, hover popover, persistence-across-reload, key-readonly enforcement, duplicate-name dedup, coexistence with query params.
- [x] Regression sweep against `environment.spec.ts`, `collection-variables.spec.ts`, `collection-auth.spec.ts`, `request-editor.spec.ts`, `workflow.spec.ts`, `import.spec.ts` — green.

## Migration
`supabase/migrations/20260424000000_request_path_variables.sql` adds `path_variables JSONB DEFAULT '[]'::jsonb` to `requests`. Existing rows get `[]` so the new section stays hidden until users add `:name` to a URL.